### PR TITLE
docs: add npx install option

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,25 @@ echo "" >> CLAUDE.md
 curl https://raw.githubusercontent.com/forrestchang/andrej-karpathy-skills/main/CLAUDE.md >> CLAUDE.md
 ```
 
+**Option C: skills CLI (global or npx)**
+
+Prerequisite: install Node.js so `npm` and `npx` are available.
+
+Use `npx` if you don't want to install the CLI globally:
+
+```bash
+npx skills add https://github.com/forrestchang/andrej-karpathy-skills --skill karpathy-guidelines
+```
+
+Or install the CLI globally first:
+
+```bash
+npm install -g skills
+skills add https://github.com/forrestchang/andrej-karpathy-skills --skill karpathy-guidelines
+```
+
+The `npx` form downloads and runs the CLI on demand, while the global install gives you a persistent `skills` command. Both install the guidelines as a skill so they are available across your Claude Code projects.
+
 ## Using with Cursor
 
 This repository includes a committed Cursor project rule ([`.cursor/rules/karpathy-guidelines.mdc`](.cursor/rules/karpathy-guidelines.mdc)) so the same guidelines apply when you open the project in Cursor. See **[CURSOR.md](CURSOR.md)** for setup, using the rule in other projects, and how this relates to Claude Code.

--- a/README.zh.md
+++ b/README.zh.md
@@ -125,6 +125,25 @@ echo "" >> CLAUDE.md
 curl https://raw.githubusercontent.com/forrestchang/andrej-karpathy-skills/main/CLAUDE.md >> CLAUDE.md
 ```
 
+**选项 C：skills CLI（全局或 npx）**
+
+前提条件：先安装 Node.js，确保 `npm` 和 `npx` 可用。
+
+如果你不想全局安装 CLI，可以直接使用 `npx`：
+
+```bash
+npx skills add https://github.com/forrestchang/andrej-karpathy-skills --skill karpathy-guidelines
+```
+
+或者先全局安装 CLI：
+
+```bash
+npm install -g skills
+skills add https://github.com/forrestchang/andrej-karpathy-skills --skill karpathy-guidelines
+```
+
+`npx` 方式会按需下载并运行 CLI，而全局安装会提供一个持久可用的 `skills` 命令。两种方式都会将这些指南作为 skill 安装，使其在你的 Claude Code 项目中可用。
+
 ## 在 Cursor 中使用
 
 本仓库包含一个已提交的 Cursor 项目规则 ([`.cursor/rules/karpathy-guidelines.mdc`](.cursor/rules/karpathy-guidelines.mdc))，因此在 Cursor 中打开项目时同样适用这些指南。详情请参见 **[CURSOR.md](CURSOR.md)**，包括如何在其他项目中使用该规则，以及它与 Claude Code 的关系。


### PR DESCRIPTION
**summary**
- add a skills CLI install option to the English README
- add the same npx/global install path to the Chinese README
- document the Node.js prerequisite and current skills add syntax

**why**
Add an install path for users who prefer the skills CLI instead of manual file copying or plugin-only setup.

**impact**
- none