### PR TITLE
Remove redundant skills[] entry from plugin.json (fixes duplicate skill registration)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Behavioral guidelines to reduce common LLM coding mistakes, derived from Andrej Karpathy's observations",
-    "version": "1.0.0"
+    "version": "1.0.1"
   },
   "plugins": [
     {
       "name": "andrej-karpathy-skills",
       "source": "./",
       "description": "Behavioral guidelines to reduce common LLM coding mistakes: Think Before Coding, Simplicity First, Surgical Changes, Goal-Driven Execution",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "author": {
         "name": "forrestchang"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "andrej-karpathy-skills",
   "description": "Behavioral guidelines to reduce common LLM coding mistakes, derived from Andrej Karpathy's observations on LLM coding pitfalls",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": {
     "name": "forrestchang"
   },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -6,6 +6,5 @@
     "name": "forrestchang"
   },
   "license": "MIT",
-  "keywords": ["guidelines", "best-practices", "coding", "karpathy"],
-  "skills": ["./skills/karpathy-guidelines"]
+  "keywords": ["guidelines", "best-practices", "coding", "karpathy"]
 }


### PR DESCRIPTION
## Summary

Remove the redundant `"skills"` entry from `plugin.json`. The `skills/` directory is already auto-discovered by Claude Code's default scan, so declaring `"skills": ["./skills/karpathy-guidelines"]` is redundant — and since Claude Code [v2.1.136](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md), which changed an explicit `skills` entry from *overriding* to *additive* with the default scan, this declaration causes the same skill to register **twice**.

## Reproduction

```
$ claude plugin details andrej-karpathy-skills@karpathy-skills
...
  Skills (2)  karpathy-guidelines, karpathy-guidelines
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                          duplicate registration

Projected token cost
  Always-on:   ~206 tok   added to every session
                ^^^
                doubles the expected ~103 tok
```

## After the fix

```
$ claude plugin details andrej-karpathy-skills@karpathy-skills
...
  Skills (1)  karpathy-guidelines

Projected token cost
  Always-on:   ~103 tok   added to every session
```

## Why is `skills/` auto-discovered?

Claude Code's plugin loader scans well-known component directories (`skills/`, `agents/`, `commands/`, `hooks/`) automatically. Explicit `skills`/`agents`/etc. entries in `plugin.json` are only needed when:

- Components live outside the default directory (e.g. `"./vendor/my-skill"`)
- You want to selectively expose a subset

Since `skills/karpathy-guidelines/` is in the standard location, the explicit entry isn't needed.

## Verified on Claude Code

```
$ claude --version
2.1.142 (Claude Code)
```

## Related Claude Code changelog entry

> **v2.1.136** — Fixed a `skills` entry in `plugin.json` hiding the plugin's default `skills/` directory, and listing a file path now shows an error instead of failing silently.

Before that fix, an explicit `skills` entry *replaced* the default scan; afterwards, both register. So the bug surfaced for plugins that already had redundant explicit declarations.
