### PR TITLE
Fix marketplace.json schema for /plugin marketplace add

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,12 +1,9 @@
 {
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "karpathy-skills",
-  "id": "karpathy-skills",
+  "description": "Behavioral guidelines to reduce common LLM coding mistakes, derived from Andrej Karpathy's observations",
   "owner": {
     "name": "forrestchang"
-  },
-  "metadata": {
-    "description": "Behavioral guidelines to reduce common LLM coding mistakes, derived from Andrej Karpathy's observations",
-    "version": "1.0.0"
   },
   "plugins": [
     {

--- a/apps/bound-book/README.md
+++ b/apps/bound-book/README.md
@@ -54,6 +54,14 @@ last backup"* — and clears to *"All changes backed up"* once you download a
 current copy. This is a local nudge only; it does not store backups for you or
 replace keeping an offsite copy.
 
+**Backup cadence (policy).** In *Licensee → Backup policy* you can set a
+required backup interval in days. When your record is otherwise fully backed up
+but the last backup is older than that interval, the Integrity screen reminds
+you — *"Your last backup is N days old (policy: every M days)"* — to download a
+fresh copy and store it offsite. Set the interval to whatever your variance
+requires; `0` turns the time-based reminder off. **Moving a copy offsite is a
+manual step this local-first app cannot do for you.**
+
 > Not legal advice. Requirements summarized from 27 CFR Part 478. Confirm
 > current ATF rules and any state requirements for your situation before
 > relying on this.

--- a/apps/bound-book/README.md
+++ b/apps/bound-book/README.md
@@ -1,0 +1,74 @@
+# Bound Book — budget A&D record (prototype)
+
+A deliberately tiny, local-first tool for keeping a firearms **Acquisition &
+Disposition (A&D)** record. Built for home-based, very small FFLs (Type 01 home
+dealers, Type 03 C&R collectors) who want to stay compliant without a full
+POS/inventory suite.
+
+Scope and rationale live in [`../../docs/bound-book-budget-prd.md`](../../docs/bound-book-budget-prd.md).
+
+## Run it
+
+No install, no server, no build step. Open `index.html` in any modern browser
+(double-click it, or `File → Open`). All data stays **on your machine** in the
+browser's local storage — nothing is sent anywhere.
+
+## What it does
+
+- **Acquire** — log a firearm coming in (all ATF-required fields; source by
+  name + address or FFL number).
+- **Dispose** — record where an open firearm went (buyer, 4473 reference,
+  eligibility documentation note).
+- **Ledger** — searchable, chronological view of every entry.
+- **Correct** — append-only corrections: the original value is never erased,
+  it's shown struck-through with the reason and the new value (the "line-out,
+  don't erase" convention).
+- **Export / Print** — print or **Save as PDF** for your official record, and
+  download a **CSV** as your backup.
+- **Integrity** — every action is stored in an append-only, **hash-chained**
+  event log; the screen verifies the chain (no gaps, nothing altered) and shows
+  the full audit trail. Editing or deleting anything after the fact breaks the
+  chain and is flagged. Also holds **full backup / restore** (verify-on-restore).
+
+## The record model (important)
+
+With the **ATF variance approved**, this app is the **electronic system of
+record**. The record is a tamper-evident, hash-chained, append-only log:
+
+- There is no edit-in-place or delete — the only way to change a recorded value
+  is a **logged correction**, so the record stays tamper-evident by construction
+  (see the **Integrity** screen and `integrity.js`).
+- Print / Save-as-PDF and CSV remain available as the human-readable
+  **surrender copy**, but they are no longer the system of record — the log is.
+
+### Back up — it's now a compliance step
+
+Because the record lives on this machine, **your backup is the continuity copy
+and the surrender copy**. Use **Integrity → Download full backup (.json)**
+regularly. Restore verifies the chain on import and **refuses a tampered or
+corrupt backup** rather than loading it.
+
+> Not legal advice. Requirements summarized from 27 CFR Part 478. Confirm
+> current ATF rules and any state requirements for your situation before
+> relying on this.
+
+## Layout
+
+| File | Role |
+|------|------|
+| `core.js` | Pure logic: validation, entry model, append-only corrections, CSV. Storage-agnostic; runs in browser and Node. |
+| `integrity.js` | Hash-chained, append-only event log: SHA-256, chain verification (no-gaps + tamper), projection to ledger entries. |
+| `core.test.js` / `integrity.test.js` | Node tests. Run: `node --test` |
+| `index.html` / `app.js` / `styles.css` | UI, localStorage persistence, print stylesheet. |
+
+## Test
+
+```
+cd apps/bound-book
+node --test
+```
+
+## Not in this tier (by design)
+
+POS/payments, integrated e-4473, multi-user roles, multi-location, barcode
+hardware, accounting. See the PRD for the intended upgrade path.

--- a/apps/bound-book/README.md
+++ b/apps/bound-book/README.md
@@ -48,6 +48,12 @@ and the surrender copy**. Use **Integrity → Download full backup (.json)**
 regularly. Restore verifies the chain on import and **refuses a tampered or
 corrupt backup** rather than loading it.
 
+The Integrity screen also tracks your last backup: it shows a warning whenever
+entries have been recorded since — *"N changes have been recorded since your
+last backup"* — and clears to *"All changes backed up"* once you download a
+current copy. This is a local nudge only; it does not store backups for you or
+replace keeping an offsite copy.
+
 > Not legal advice. Requirements summarized from 27 CFR Part 478. Confirm
 > current ATF rules and any state requirements for your situation before
 > relying on this.

--- a/apps/bound-book/README.md
+++ b/apps/bound-book/README.md
@@ -25,6 +25,8 @@ browser's local storage — nothing is sent anywhere.
   don't erase" convention).
 - **Export / Print** — print or **Save as PDF** for your official record, and
   download a **CSV** as your backup.
+- **Packages** — track what is inbound from USPS, UPS and FedEx, and catch the
+  gap between *delivered* and *written into the bound book* (see below).
 - **Integrity** — every action is stored in an append-only, **hash-chained**
   event log; the screen verifies the chain (no gaps, nothing altered) and shows
   the full audit trail. Editing or deleting anything after the fact breaks the
@@ -66,13 +68,68 @@ manual step this local-first app cannot do for you.**
 > current ATF rules and any state requirements for your situation before
 > relying on this.
 
+## Inbound packages
+
+A firearm that arrives is an acquisition waiting to be logged. This screen
+tracks what is on its way and flags the gap between the two.
+
+It is deliberately **not** an email scraper. Status comes from the carriers'
+own APIs, which means it also sees the things no email would ever tell you:
+
+- a package that **stopped scanning** four or more days ago;
+- a package **past the date you expected it**;
+- a package **delivered but not yet in the bound book** — escalating once more
+  than one business day has passed, since an acquisition is due by the close of
+  the next business day after receipt.
+
+**Log as acquisition** carries a delivered package into the Acquire form with
+the delivery date prefilled, then links the two so the reminder clears. The
+firearm's details are still yours to enter — tracking cannot tell you what was
+in the box.
+
+### It is not part of the legal record
+
+Package data lives in its own store, outside the hash-chained log. Carrier
+status is third-party logistics information, not a regulated A&D field, so
+putting it in the chain would pad your system of record with noise you cannot
+correct or remove. Rows on this screen can be edited and deleted freely. The
+only thing that ever reaches the chain is an acquisition you log yourself.
+
+### There is no "everything coming to my address" API
+
+Worth stating plainly, because it shapes the design. USPS, UPS and FedEx all
+offer tracking APIs that take a *tracking number*. None offers a feed of
+everything inbound to an address — the consumer dashboards that show that
+(Informed Delivery, UPS My Choice, FedEx Delivery Manager) are web pages with
+no public API.
+
+So the poller in [`tracker/`](tracker/) does two separate things: it signs in to
+those dashboards to **discover tracking numbers**, then resolves every number
+against the **official API** for real status. Your carrier passwords are never
+stored — you sign in yourself once per carrier in a real browser window, and
+only the session is saved.
+
+The poller is a separate Node program because this app has no server and never
+gets one: a `file://` page cannot call those APIs, and an API secret in a web
+page is a published secret. The two halves meet over a file, the same way
+backup and restore already work:
+
+```
+Packages → Download tracking list   →   node poll.js poll --list tracking-list.json
+                                    →   Packages → Import snapshot
+```
+
+Setup, credentials and options: [`tracker/README.md`](tracker/README.md).
+
 ## Layout
 
 | File | Role |
 |------|------|
 | `core.js` | Pure logic: validation, entry model, append-only corrections, CSV. Storage-agnostic; runs in browser and Node. |
 | `integrity.js` | Hash-chained, append-only event log: SHA-256, chain verification (no-gaps + tamper), projection to ledger entries. |
-| `core.test.js` / `integrity.test.js` | Node tests. Run: `node --test` |
+| `packages.js` | Pure logic for the inbound package registry: carrier detection, status normalization, staleness, reconciliation against the ledger. Outside the chain by design. |
+| `tracker/` | Node poller: official USPS/UPS/FedEx APIs for status, portal sign-in for discovery. Has its own README. |
+| `core.test.js` / `integrity.test.js` / `packages.test.js` / `tracker/carriers.test.js` | Node tests. Run: `node --test` |
 | `index.html` / `app.js` / `styles.css` | UI, localStorage persistence, print stylesheet. |
 
 ## Test

--- a/apps/bound-book/app.js
+++ b/apps/bound-book/app.js
@@ -6,6 +6,7 @@
   var LOG_KEY = 'boundbook.log.v1';
   var PROFILE_KEY = 'boundbook.profile.v1';
   var DISCLAIMER_KEY = 'boundbook.disclaimer.v1';
+  var BACKUP_KEY = 'boundbook.lastbackup.v1';
 
   // --- persistence (append-only event log; the ledger is a projection) ---
   function loadLog() {
@@ -13,6 +14,11 @@
     catch (e) { return []; }
   }
   function saveLog() { localStorage.setItem(LOG_KEY, JSON.stringify(log)); }
+  function loadLastBackup() {
+    try { return JSON.parse(localStorage.getItem(BACKUP_KEY)) || null; }
+    catch (e) { return null; }
+  }
+  function saveLastBackup(marker) { localStorage.setItem(BACKUP_KEY, JSON.stringify(marker)); }
   function loadProfile() {
     try { return JSON.parse(localStorage.getItem(PROFILE_KEY)) || {}; }
     catch (e) { return {}; }
@@ -34,6 +40,7 @@
     return 'e' + Date.now() + Math.floor(Math.random() * 1e6);
   }
   function nowIso() { return new Date().toISOString(); }
+  function shortDate(iso) { return String(iso || '').replace('T', ' ').replace(/\..*/, ''); }
   function formData(form) {
     var o = {};
     new FormData(form).forEach(function (v, k) { o[k] = String(v).trim(); });
@@ -268,6 +275,18 @@
     if (e.type === 'correct') return 'Corrected ' + esc(e.payload.field) + ' → ' + esc(e.payload.newValue) + ' (' + esc(e.payload.reason) + ')';
     return esc(e.type);
   }
+  function backupBanner() {
+    var s = INT.backupStatus(log, lastBackup);
+    if (s.upToDate) {
+      var when = s.lastBackupAt ? ' (last backup ' + esc(shortDate(s.lastBackupAt)) + ')' : '';
+      return '<div class="backup-ok">&#10003; All changes backed up' + when + '.</div>';
+    }
+    var noun = s.pending === 1 ? 'change has' : 'changes have';
+    var lead = s.neverBackedUp
+      ? 'No backup yet — '
+      : (esc(s.pending) + ' ' + noun + ' been recorded since your last backup' + (s.lastBackupAt ? ' (' + esc(shortDate(s.lastBackupAt)) + ')' : '') + '. ');
+    return '<div class="backup-warn">&#9888; ' + lead + 'Download a backup so this record survives loss of this device.</div>';
+  }
   function renderIntegrity() {
     var res = INT.verifyChain(log);
     var statusEl = document.getElementById('integrity-status');
@@ -276,9 +295,10 @@
       document.getElementById('integrity-log').innerHTML = '';
       return;
     }
-    statusEl.innerHTML = res.ok
+    statusEl.innerHTML = (res.ok
       ? '<div class="chain-ok">&#10003; Chain verified — ' + res.count + ' entr' + (res.count === 1 ? 'y' : 'ies') + ', no gaps, nothing altered.</div>'
-      : '<div class="chain-bad">&#10007; Integrity check FAILED. ' + esc(res.reason) + '</div>';
+      : '<div class="chain-bad">&#10007; Integrity check FAILED. ' + esc(res.reason) + '</div>')
+      + backupBanner();
 
     var rows = log.map(function (e) {
       var broken = !res.ok && e.seq >= res.brokenAt;
@@ -295,8 +315,11 @@
   }
 
   // --- backup / restore (continuity of the legal record) ---
+  var lastBackup = loadLastBackup();
+
   document.getElementById('btn-backup').addEventListener('click', function () {
-    var backup = INT.makeBackup(log, nowIso());
+    var at = nowIso();
+    var backup = INT.makeBackup(log, at);
     var blob = new Blob([JSON.stringify(backup, null, 2)], { type: 'application/json' });
     var url = URL.createObjectURL(blob);
     var a = document.createElement('a');
@@ -304,6 +327,10 @@
     a.download = 'bound-book-backup.json';
     a.click();
     URL.revokeObjectURL(url);
+    // Mark everything currently recorded as backed up.
+    lastBackup = { seq: INT.headSeq(log), at: at };
+    saveLastBackup(lastBackup);
+    renderIntegrity();
   });
 
   var restoreInput = document.getElementById('restore-input');
@@ -326,6 +353,10 @@
       log = res.log;
       saveLog();
       entries = INT.project(log);
+      // The restored data matches a backup file that exists on disk, so it is
+      // current as of this restore.
+      lastBackup = { seq: INT.headSeq(log), at: nowIso() };
+      saveLastBackup(lastBackup);
       restoreInput.value = '';
       msg.innerHTML = '<div class="chain-ok">Restored ' + res.log.length + ' entries. Chain verified.</div>';
       renderIntegrity();

--- a/apps/bound-book/app.js
+++ b/apps/bound-book/app.js
@@ -3,10 +3,12 @@
   'use strict';
   var BB = window.BoundBook;
   var INT = window.Integrity;
+  var PK = window.Packages;
   var LOG_KEY = 'boundbook.log.v1';
   var PROFILE_KEY = 'boundbook.profile.v1';
   var DISCLAIMER_KEY = 'boundbook.disclaimer.v1';
   var BACKUP_KEY = 'boundbook.lastbackup.v1';
+  var PACKAGES_KEY = 'boundbook.packages.v1';
 
   // --- persistence (append-only event log; the ledger is a projection) ---
   function loadLog() {
@@ -24,9 +26,16 @@
     catch (e) { return {}; }
   }
   function saveProfile(p) { localStorage.setItem(PROFILE_KEY, JSON.stringify(p)); }
+  // Packages are a working list, stored outside the chained log on purpose.
+  function loadPackages() {
+    try { return JSON.parse(localStorage.getItem(PACKAGES_KEY)) || []; }
+    catch (e) { return []; }
+  }
+  function savePackages() { localStorage.setItem(PACKAGES_KEY, JSON.stringify(packages)); }
 
   var log = loadLog();
   var entries = INT.project(log);
+  var packages = loadPackages();
 
   // Record an action as a new chained event, persist, and re-project the ledger.
   function commit(type, payload) {
@@ -40,7 +49,9 @@
     return 'e' + Date.now() + Math.floor(Math.random() * 1e6);
   }
   function nowIso() { return new Date().toISOString(); }
-  function shortDate(iso) { return String(iso || '').replace('T', ' ').replace(/\..*/, ''); }
+  // Carrier scan times may arrive without fractional seconds, so the trailing
+  // Z has to go too; for a toISOString() value the first replace already ate it.
+  function shortDate(iso) { return String(iso || '').replace('T', ' ').replace(/\..*/, '').replace(/Z$/, ''); }
   function formData(form) {
     var o = {};
     new FormData(form).forEach(function (v, k) { o[k] = String(v).trim(); });
@@ -65,6 +76,7 @@
       b.classList.toggle('active', b.dataset.view === view);
     });
     if (view === 'dispose') renderDisposeOptions();
+    if (view === 'packages') renderPackages();
     if (view === 'ledger') renderLedger();
     if (view === 'export') renderPrintLedger();
     if (view === 'integrity') renderIntegrity();
@@ -82,7 +94,11 @@
     if (!res.ok) return;
     data.entryId = newId();
     commit('acquire', data);
+    // If this came from a tracked package, tie the two together so the package
+    // stops showing as delivered-but-not-logged.
+    if (pendingPackageId) linkPackage(pendingPackageId, data.entryId);
     this.reset();
+    clearPendingPackage();
     showErrors(document.getElementById('acquire-errors'), []);
     show('ledger');
   });
@@ -367,6 +383,235 @@
       restoreInput.value = '';
       msg.innerHTML = '<div class="chain-ok">Restored ' + res.log.length + ' entries. Chain verified.</div>';
       renderIntegrity();
+    };
+    reader.readAsText(file);
+  });
+
+  // --- packages (inbound tracking; NOT part of the chained A&D record) ---
+  // Carrier data is third-party logistics information, not a regulated field,
+  // so it lives in its own store and rows here can be edited or removed freely.
+  // The single path into the legal record is "Log as acquisition", which writes
+  // an ordinary acquire event through commit().
+
+  var pendingPackageId = null;
+
+  function findPackage(id) {
+    return packages.filter(function (p) { return p.id === id; })[0];
+  }
+  function plural(n) { return n === 1 ? '' : 's'; }
+  function pkgRank(p) {
+    if (PK.needsLogging(p)) return 0;
+    if (PK.isActive(p)) return 1;
+    return 2;
+  }
+
+  function renderPackages() {
+    var rec = PK.reconcile(packages, entries, nowIso());
+    renderPackageAlerts(rec);
+    renderPackageTable(rec);
+  }
+
+  function alertLine(cls, text) { return '<div class="' + cls + '">' + text + '</div>'; }
+
+  function renderPackageAlerts(rec) {
+    var out = [];
+    if (rec.lateToLog.length) {
+      out.push(alertLine('chain-bad', '&#10007; ' + rec.lateToLog.length + ' delivered package' +
+        plural(rec.lateToLog.length) + ' not yet in the bound book. An acquisition is due by the close ' +
+        'of the next business day after you receive the firearm.'));
+    }
+    var waiting = rec.toLog.length - rec.lateToLog.length;
+    if (waiting > 0) {
+      out.push(alertLine('backup-warn', '&#9888; ' + waiting + ' delivered package' + plural(waiting) +
+        ' waiting to be logged as ' + (waiting === 1 ? 'an acquisition' : 'acquisitions') + '.'));
+    }
+    if (rec.stalled.length) {
+      out.push(alertLine('backup-warn', '&#9888; ' + rec.stalled.length + ' package' + plural(rec.stalled.length) +
+        ' stopped scanning ' + PK.DEFAULT_STALL_DAYS + '+ days ago. Nothing would have emailed you about this.'));
+    }
+    if (rec.overdue.length) {
+      out.push(alertLine('backup-warn', '&#9888; ' + rec.overdue.length + ' package' + plural(rec.overdue.length) +
+        ' past the date you expected ' + (rec.overdue.length === 1 ? 'it' : 'them') + '.'));
+    }
+    if (rec.orphanLinks.length) {
+      out.push(alertLine('backup-warn', '&#9888; ' + rec.orphanLinks.length + ' package' + plural(rec.orphanLinks.length) +
+        ' point at a ledger entry that no longer exists — likely a restore from an older backup.'));
+    }
+    if (!out.length) {
+      out.push(alertLine('chain-ok', packages.length
+        ? '&#10003; ' + rec.active.length + ' inbound, nothing needs attention.'
+        : '&#10003; No packages tracked yet.'));
+    }
+    document.getElementById('packages-alerts').innerHTML = out.join('');
+  }
+
+  function renderPackageTable(rec) {
+    var el = document.getElementById('packages-table');
+    if (!packages.length) {
+      el.innerHTML = '<p class="empty">Nothing tracked yet. Add what you are expecting above, ' +
+        'or run the poller to pull in what your carrier accounts already know about.</p>';
+      return;
+    }
+    var now = nowIso();
+    // Last flag wins, so the most serious one is applied last.
+    var flagged = {};
+    rec.overdue.forEach(function (p) { flagged[p.id] = 'Past its expected date'; });
+    rec.stalled.forEach(function (p) {
+      flagged[p.id] = 'No scan in ' + PK.daysBetween(p.lastScan.at, now) + ' days';
+    });
+    rec.lateToLog.forEach(function (p) { flagged[p.id] = 'Not logged as an acquisition'; });
+
+    var ranked = packages.slice().sort(function (a, b) {
+      return pkgRank(a) - pkgRank(b) ||
+        String(a.description).localeCompare(String(b.description));
+    });
+
+    var head = '<tr><th>Status</th><th>What</th><th>Carrier / tracking</th>' +
+      '<th>Last scan</th><th>Expected</th><th class="no-print"></th></tr>';
+    var body = ranked.map(function (p) {
+      var status = '<td><span class="pkg-status pkg-' + esc(p.status) + '">' +
+        esc(PK.STATUS_LABELS[p.status] || p.status) + '</span></td>';
+
+      var what = '<td>' + esc(p.description);
+      if (p.source === 'portal') {
+        what += '<span class="pkg-note">found on the ' + esc(PK.carrierLabel(p.carrier)) + ' portal</span>';
+      }
+      if (p.linkedEntryId) what += '<span class="pkg-note">logged as an acquisition</span>';
+      if (flagged[p.id]) what += '<span class="pkg-flag">' + esc(flagged[p.id]) + '</span>';
+      what += '</td>';
+
+      var tn = '<td>' + esc(PK.carrierLabel(p.carrier)) + (p.trackingNumber
+        ? '<span class="pkg-note mono">' + esc(p.trackingNumber) + '</span>'
+        : '<span class="pkg-note">no tracking number yet</span>') + '</td>';
+
+      var scan = '<td>' + (p.lastScan
+        ? esc(p.lastScan.description) + '<span class="pkg-note">' + esc(shortDate(p.lastScan.at)) +
+          (p.lastScan.location ? ' · ' + esc(p.lastScan.location) : '') + '</span>'
+        : '—') + '</td>';
+
+      var exp = '<td>' + esc(p.expectedBy || '—') + '</td>';
+
+      var actions = '<td class="no-print">';
+      if (PK.needsLogging(p)) {
+        actions += '<button type="button" class="link-btn" data-log="' + esc(p.id) + '">Log as acquisition</button><br>';
+      }
+      actions += '<button type="button" class="link-btn" data-drop="' + esc(p.id) + '">Remove</button></td>';
+
+      return '<tr class="' + (flagged[p.id] ? 'row-warn' : '') + '">' +
+        status + what + tn + scan + exp + actions + '</tr>';
+    }).join('');
+
+    el.innerHTML = '<table><thead>' + head + '</thead><tbody>' + body + '</tbody></table>';
+    el.querySelectorAll('[data-log]').forEach(function (b) {
+      b.addEventListener('click', function () { startAcquisitionFrom(b.dataset.log); });
+    });
+    el.querySelectorAll('[data-drop]').forEach(function (b) {
+      b.addEventListener('click', function () { dropPackage(b.dataset.drop); });
+    });
+  }
+
+  document.getElementById('package-form').addEventListener('submit', function (ev) {
+    ev.preventDefault();
+    var data = formData(this);
+    var res = PK.validatePackage(data);
+    showErrors(document.getElementById('package-errors'), res.errors);
+    if (!res.ok) return;
+    packages = packages.concat([PK.newPackage(data, newId(), nowIso())]);
+    savePackages();
+    this.reset();
+    renderPackages();
+  });
+
+  // Removing a package touches nothing regulated — this list is not the record.
+  function dropPackage(id) {
+    var p = findPackage(id);
+    if (!p) return;
+    if (!window.confirm('Remove "' + p.description + '" from the package list? ' +
+      'This does not touch the A&D record.')) return;
+    packages = packages.filter(function (x) { return x.id !== id; });
+    savePackages();
+    renderPackages();
+  }
+
+  // --- the handoff into the legal record ---
+
+  function deliveryDate(p) {
+    var at = (p.lastScan && p.lastScan.at) || '';
+    return /^\d{4}-\d{2}-\d{2}/.test(at) ? at.slice(0, 10) : '';
+  }
+
+  function startAcquisitionFrom(id) {
+    var p = findPackage(id);
+    if (!p) return;
+    pendingPackageId = id;
+    var banner = document.getElementById('acquire-from-package');
+    banner.innerHTML = 'Logging the acquisition for <strong>' + esc(p.description) + '</strong>' +
+      (p.trackingNumber ? ' (' + esc(PK.carrierLabel(p.carrier)) + ' ' + esc(p.trackingNumber) + ')' : '') +
+      '. The carrier cannot tell you what was in the box, so the firearm details are yours to enter. ' +
+      '<button type="button" class="link-btn" id="cancel-from-package">Cancel</button>';
+    banner.classList.remove('hidden');
+    document.getElementById('cancel-from-package').addEventListener('click', clearPendingPackage);
+    // The delivery scan date is real carrier data, so it is worth prefilling.
+    // Nothing else on the form can be known from tracking.
+    var d = deliveryDate(p);
+    if (d) document.getElementById('acquire-form').dateReceived.value = d;
+    show('acquire');
+  }
+
+  function clearPendingPackage() {
+    pendingPackageId = null;
+    var banner = document.getElementById('acquire-from-package');
+    banner.innerHTML = '';
+    banner.classList.add('hidden');
+  }
+
+  function linkPackage(id, entryId) {
+    packages = packages.map(function (p) {
+      return p.id === id ? PK.linkToEntry(p, entryId, nowIso()) : p;
+    });
+    savePackages();
+  }
+
+  // --- poller round-trip (same shape as backup/restore: a file, not a server) ---
+
+  document.getElementById('btn-tracking-list').addEventListener('click', function () {
+    var list = {
+      app: 'bound-book-tracking-list',
+      version: 1,
+      exportedAt: nowIso(),
+      packages: PK.trackingList(packages)
+    };
+    var blob = new Blob([JSON.stringify(list, null, 2)], { type: 'application/json' });
+    var url = URL.createObjectURL(blob);
+    var a = document.createElement('a');
+    a.href = url;
+    a.download = 'tracking-list.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  });
+
+  var snapshotInput = document.getElementById('snapshot-input');
+  snapshotInput.addEventListener('change', function () {
+    var file = this.files && this.files[0];
+    var msg = document.getElementById('snapshot-msg');
+    if (!file) return;
+    var reader = new FileReader();
+    reader.onload = function () {
+      var data = null;
+      try { data = JSON.parse(String(reader.result)); } catch (e) { /* reported below */ }
+      if (!data || data.app !== 'bound-book-tracker' || !Array.isArray(data.packages)) {
+        msg.innerHTML = '<div class="chain-bad">That is not a poller snapshot. Expected ' +
+          'package-snapshot.json, written by tracker/poll.js.</div>';
+        snapshotInput.value = '';
+        return;
+      }
+      var res = PK.mergeSnapshot(packages, data, nowIso(), newId);
+      packages = res.packages;
+      savePackages();
+      snapshotInput.value = '';
+      msg.innerHTML = '<div class="chain-ok">Imported ' + data.packages.length + ' package' +
+        plural(data.packages.length) + ': ' + res.updated + ' updated, ' + res.added + ' newly discovered.</div>';
+      renderPackages();
     };
     reader.readAsText(file);
   });

--- a/apps/bound-book/app.js
+++ b/apps/bound-book/app.js
@@ -277,15 +277,22 @@
   }
   function backupBanner() {
     var s = INT.backupStatus(log, lastBackup);
-    if (s.upToDate) {
-      var when = s.lastBackupAt ? ' (last backup ' + esc(shortDate(s.lastBackupAt)) + ')' : '';
-      return '<div class="backup-ok">&#10003; All changes backed up' + when + '.</div>';
+    // Priority 1: unsaved changes are the most urgent — data would be lost.
+    if (!s.upToDate) {
+      var noun = s.pending === 1 ? 'change has' : 'changes have';
+      var lead = s.neverBackedUp
+        ? 'No backup yet — '
+        : (esc(s.pending) + ' ' + noun + ' been recorded since your last backup' + (s.lastBackupAt ? ' (' + esc(shortDate(s.lastBackupAt)) + ')' : '') + '. ');
+      return '<div class="backup-warn">&#9888; ' + lead + 'Download a backup so this record survives loss of this device.</div>';
     }
-    var noun = s.pending === 1 ? 'change has' : 'changes have';
-    var lead = s.neverBackedUp
-      ? 'No backup yet — '
-      : (esc(s.pending) + ' ' + noun + ' been recorded since your last backup' + (s.lastBackupAt ? ' (' + esc(shortDate(s.lastBackupAt)) + ')' : '') + '. ');
-    return '<div class="backup-warn">&#9888; ' + lead + 'Download a backup so this record survives loss of this device.</div>';
+    // Priority 2: fully backed up, but the calendar cadence is due (policy).
+    var interval = parseInt(loadProfile().backupIntervalDays, 10) || 0;
+    var due = INT.backupOverdue(lastBackup, nowIso(), interval);
+    if (due.overdue) {
+      return '<div class="backup-warn">&#9888; Your last backup is ' + esc(due.ageDays) + ' days old (policy: every ' + esc(interval) + ' days). Download a fresh copy and store it offsite.</div>';
+    }
+    var when = s.lastBackupAt ? ' (last backup ' + esc(shortDate(s.lastBackupAt)) + ')' : '';
+    return '<div class="backup-ok">&#10003; All changes backed up' + when + '.</div>';
   }
   function renderIntegrity() {
     var res = INT.verifyChain(log);
@@ -368,7 +375,7 @@
   (function initProfile() {
     var form = document.getElementById('profile-form');
     var p = loadProfile();
-    ['name', 'ffl', 'address'].forEach(function (k) { if (form[k]) form[k].value = p[k] || ''; });
+    ['name', 'ffl', 'address', 'backupIntervalDays'].forEach(function (k) { if (form[k]) form[k].value = p[k] || ''; });
     form.addEventListener('submit', function (ev) {
       ev.preventDefault();
       saveProfile(formData(this));

--- a/apps/bound-book/app.js
+++ b/apps/bound-book/app.js
@@ -1,0 +1,364 @@
+// app.js — DOM wiring + localStorage persistence. Pure logic lives in core.js.
+(function () {
+  'use strict';
+  var BB = window.BoundBook;
+  var INT = window.Integrity;
+  var LOG_KEY = 'boundbook.log.v1';
+  var PROFILE_KEY = 'boundbook.profile.v1';
+  var DISCLAIMER_KEY = 'boundbook.disclaimer.v1';
+
+  // --- persistence (append-only event log; the ledger is a projection) ---
+  function loadLog() {
+    try { return JSON.parse(localStorage.getItem(LOG_KEY)) || []; }
+    catch (e) { return []; }
+  }
+  function saveLog() { localStorage.setItem(LOG_KEY, JSON.stringify(log)); }
+  function loadProfile() {
+    try { return JSON.parse(localStorage.getItem(PROFILE_KEY)) || {}; }
+    catch (e) { return {}; }
+  }
+  function saveProfile(p) { localStorage.setItem(PROFILE_KEY, JSON.stringify(p)); }
+
+  var log = loadLog();
+  var entries = INT.project(log);
+
+  // Record an action as a new chained event, persist, and re-project the ledger.
+  function commit(type, payload) {
+    log = INT.appendEvent(log, type, payload, nowIso());
+    saveLog();
+    entries = INT.project(log);
+  }
+
+  function newId() {
+    if (window.crypto && crypto.randomUUID) return crypto.randomUUID();
+    return 'e' + Date.now() + Math.floor(Math.random() * 1e6);
+  }
+  function nowIso() { return new Date().toISOString(); }
+  function formData(form) {
+    var o = {};
+    new FormData(form).forEach(function (v, k) { o[k] = String(v).trim(); });
+    return o;
+  }
+  function esc(s) {
+    return String(s == null ? '' : s).replace(/[&<>"]/g, function (c) {
+      return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c];
+    });
+  }
+  function showErrors(el, errors) {
+    el.innerHTML = errors.length
+      ? '<ul>' + errors.map(function (e) { return '<li>' + esc(e) + '</li>'; }).join('') + '</ul>'
+      : '';
+  }
+
+  // --- navigation ---
+  function show(view) {
+    document.querySelectorAll('.view').forEach(function (s) { s.classList.add('hidden'); });
+    document.getElementById('view-' + view).classList.remove('hidden');
+    document.querySelectorAll('nav button').forEach(function (b) {
+      b.classList.toggle('active', b.dataset.view === view);
+    });
+    if (view === 'dispose') renderDisposeOptions();
+    if (view === 'ledger') renderLedger();
+    if (view === 'export') renderPrintLedger();
+    if (view === 'integrity') renderIntegrity();
+  }
+  document.querySelectorAll('nav button').forEach(function (b) {
+    b.addEventListener('click', function () { show(b.dataset.view); });
+  });
+
+  // --- acquire ---
+  document.getElementById('acquire-form').addEventListener('submit', function (ev) {
+    ev.preventDefault();
+    var data = formData(this);
+    var res = BB.validateAcquisition(data);
+    showErrors(document.getElementById('acquire-errors'), res.errors);
+    if (!res.ok) return;
+    data.entryId = newId();
+    commit('acquire', data);
+    this.reset();
+    showErrors(document.getElementById('acquire-errors'), []);
+    show('ledger');
+  });
+
+  // --- dispose ---
+  function openEntries() { return entries.filter(function (e) { return e.status === 'open'; }); }
+
+  function renderDisposeOptions() {
+    var sel = document.getElementById('dispose-select');
+    var open = openEntries();
+    if (!open.length) {
+      sel.innerHTML = '<option value="">No open firearms</option>';
+      return;
+    }
+    sel.innerHTML = open.map(function (e) {
+      var label = BB.currentValue(e, 'acquisition.mfrImporter') + ' ' +
+        BB.currentValue(e, 'acquisition.model') + ' — SN ' +
+        BB.currentValue(e, 'acquisition.serial');
+      return '<option value="' + esc(e.id) + '">' + esc(label) + '</option>';
+    }).join('');
+  }
+
+  document.getElementById('dispose-form').addEventListener('submit', function (ev) {
+    ev.preventDefault();
+    var id = document.getElementById('dispose-select').value;
+    var errEl = document.getElementById('dispose-errors');
+    if (!id) { showErrors(errEl, ['Select an open firearm first.']); return; }
+    var data = formData(this);
+    var res = BB.validateDisposition(data);
+    showErrors(errEl, res.errors);
+    if (!res.ok) return;
+    data.entryId = id;
+    commit('dispose', data);
+    this.reset();
+    show('ledger');
+  });
+
+  // --- ledger ---
+  var LEDGER_COLS = [
+    ['Received', 'acquisition.dateReceived'],
+    ['Mfr/Importer', 'acquisition.mfrImporter'],
+    ['Model', 'acquisition.model'],
+    ['Serial', 'acquisition.serial'],
+    ['Type', 'acquisition.type'],
+    ['Caliber', 'acquisition.caliber']
+  ];
+
+  function fieldCell(e, path) {
+    // Show current value; if corrected, show the original struck out beneath.
+    var corr = null;
+    e.corrections.forEach(function (c) { if (c.field === path) corr = c; });
+    var cur = esc(BB.currentValue(e, path));
+    if (!corr) return cur;
+    var orig = esc(corr.oldValue);
+    return cur + '<span class="corr">was <span class="struck">' + orig + '</span> — ' + esc(corr.reason) + '</span>';
+  }
+
+  function matches(e, q) {
+    if (!q) return true;
+    q = q.toLowerCase();
+    var hay = [
+      BB.currentValue(e, 'acquisition.serial'),
+      BB.currentValue(e, 'acquisition.model'),
+      BB.currentValue(e, 'acquisition.mfrImporter'),
+      BB.party(e, 'source'),
+      e.disposition ? BB.party(e, 'buyer') : ''
+    ].join(' ').toLowerCase();
+    return hay.indexOf(q) !== -1;
+  }
+
+  function renderLedger() {
+    var q = document.getElementById('ledger-search').value.trim();
+    var rows = entries.filter(function (e) { return matches(e, q); });
+    var el = document.getElementById('ledger-table');
+    if (!rows.length) {
+      el.innerHTML = '<p class="empty">No entries yet. Start with an acquisition.</p>';
+      return;
+    }
+    var head = '<tr>' + LEDGER_COLS.map(function (c) { return '<th>' + c[0] + '</th>'; }).join('') +
+      '<th>Source</th><th>Status</th><th>Disposition</th></tr>';
+    var body = rows.map(function (e) {
+      var cells = LEDGER_COLS.map(function (c) { return '<td>' + fieldCell(e, c[1]) + '</td>'; }).join('');
+      var source = '<td>' + esc(BB.party(e, 'source')) + '</td>';
+      var status = '<td class="status-' + e.status + '">' + e.status + '</td>';
+      var disp = '<td>';
+      if (e.disposition) {
+        disp += esc(BB.currentValue(e, 'disposition.date')) + '<br>' +
+          esc(BB.party(e, 'buyer')) + '<br>' +
+          '4473: ' + esc(BB.currentValue(e, 'disposition.formSerial'));
+      } else {
+        disp += '—';
+      }
+      disp += '</td>';
+      var action = '<td class="no-print"><button type="button" class="link-btn" data-correct="' + esc(e.id) + '">Correct</button></td>';
+      return '<tr>' + cells + source + status + disp + action + '</tr>';
+    }).join('');
+    el.innerHTML = '<table><thead>' + head + '<th class="no-print"></th></thead><tbody>' + body + '</tbody></table>';
+    el.querySelectorAll('[data-correct]').forEach(function (b) {
+      b.addEventListener('click', function () { openCorrection(b.dataset.correct); });
+    });
+  }
+  document.getElementById('ledger-search').addEventListener('input', renderLedger);
+
+  // --- corrections (append-only) ---
+  var correctingId = null;
+  function correctableFields(entry) {
+    var fields = BB.ACQ_FIELDS.map(function (f) {
+      return { path: 'acquisition.' + f.key, label: f.label };
+    });
+    if (entry.disposition) {
+      BB.DISP_FIELDS.forEach(function (f) {
+        fields.push({ path: 'disposition.' + f.key, label: 'Disposition — ' + f.label });
+      });
+    }
+    return fields;
+  }
+  function openCorrection(id) {
+    correctingId = id;
+    var entry = entries.find(function (e) { return e.id === id; });
+    var sel = document.getElementById('correct-field');
+    sel.innerHTML = correctableFields(entry).map(function (f) {
+      return '<option value="' + esc(f.path) + '">' + esc(f.label) + ' (now: ' +
+        esc(BB.currentValue(entry, f.path)) + ')</option>';
+    }).join('');
+    showErrors(document.getElementById('correct-errors'), []);
+    document.getElementById('correct-form').reset();
+    document.getElementById('correct-target').textContent =
+      'SN ' + BB.currentValue(entry, 'acquisition.serial') + ' — the original stays on record, struck through.';
+    document.getElementById('correct-modal').classList.remove('hidden');
+  }
+  document.getElementById('correct-cancel').addEventListener('click', function () {
+    document.getElementById('correct-modal').classList.add('hidden');
+  });
+  document.getElementById('correct-form').addEventListener('submit', function (ev) {
+    ev.preventDefault();
+    var data = formData(this);
+    if (!data.newValue || !data.reason) {
+      showErrors(document.getElementById('correct-errors'), ['Corrected value and reason are both required.']);
+      return;
+    }
+    commit('correct', { entryId: correctingId, field: data.field, newValue: data.newValue, reason: data.reason });
+    document.getElementById('correct-modal').classList.add('hidden');
+    renderLedger();
+  });
+
+  // --- export ---
+  function renderPrintLedger() {
+    var p = loadProfile();
+    var header = '<div class="ledger-header"><h2>Acquisition &amp; Disposition Record</h2>' +
+      '<div class="meta">' + esc(p.name || '') +
+      (p.ffl ? ' · FFL# ' + esc(p.ffl) : '') +
+      (p.address ? ' · ' + esc(p.address) : '') + '</div></div>';
+    var el = document.getElementById('print-ledger');
+    if (!entries.length) { el.innerHTML = header + '<p class="empty">No entries yet.</p>'; return; }
+    var head = '<tr><th>Received</th><th>Mfr/Importer</th><th>Model</th><th>Serial</th>' +
+      '<th>Type</th><th>Caliber</th><th>Source</th><th>Disp. date</th><th>Buyer</th><th>4473</th></tr>';
+    var body = entries.map(function (e) {
+      return '<tr>' +
+        td(BB.currentValue(e, 'acquisition.dateReceived')) +
+        td(BB.currentValue(e, 'acquisition.mfrImporter')) +
+        td(BB.currentValue(e, 'acquisition.model')) +
+        td(BB.currentValue(e, 'acquisition.serial')) +
+        td(BB.currentValue(e, 'acquisition.type')) +
+        td(BB.currentValue(e, 'acquisition.caliber')) +
+        td(BB.party(e, 'source')) +
+        td(e.disposition ? BB.currentValue(e, 'disposition.date') : '') +
+        td(e.disposition ? BB.party(e, 'buyer') : '') +
+        td(e.disposition ? BB.currentValue(e, 'disposition.formSerial') : '') +
+        '</tr>';
+    }).join('');
+    el.innerHTML = header + '<table><thead>' + head + '</thead><tbody>' + body + '</tbody></table>';
+  }
+  function td(v) { return '<td>' + esc(v) + '</td>'; }
+
+  document.getElementById('btn-print').addEventListener('click', function () { window.print(); });
+  document.getElementById('btn-csv').addEventListener('click', function () {
+    var blob = new Blob([BB.toCSV(entries)], { type: 'text/csv' });
+    var url = URL.createObjectURL(blob);
+    var a = document.createElement('a');
+    a.href = url;
+    a.download = 'bound-book-backup.csv';
+    a.click();
+    URL.revokeObjectURL(url);
+  });
+
+  // --- integrity view ---
+  function eventSummary(e) {
+    if (e.type === 'acquire') return 'Acquired ' + esc(e.payload.mfrImporter) + ' ' + esc(e.payload.model) + ' — SN ' + esc(e.payload.serial);
+    if (e.type === 'dispose') return 'Disposed entry (4473 ' + esc(e.payload.formSerial) + ')';
+    if (e.type === 'correct') return 'Corrected ' + esc(e.payload.field) + ' → ' + esc(e.payload.newValue) + ' (' + esc(e.payload.reason) + ')';
+    return esc(e.type);
+  }
+  function renderIntegrity() {
+    var res = INT.verifyChain(log);
+    var statusEl = document.getElementById('integrity-status');
+    if (!log.length) {
+      statusEl.innerHTML = '<div class="chain-ok">No entries yet — nothing to verify.</div>';
+      document.getElementById('integrity-log').innerHTML = '';
+      return;
+    }
+    statusEl.innerHTML = res.ok
+      ? '<div class="chain-ok">&#10003; Chain verified — ' + res.count + ' entr' + (res.count === 1 ? 'y' : 'ies') + ', no gaps, nothing altered.</div>'
+      : '<div class="chain-bad">&#10007; Integrity check FAILED. ' + esc(res.reason) + '</div>';
+
+    var rows = log.map(function (e) {
+      var broken = !res.ok && e.seq >= res.brokenAt;
+      return '<tr class="' + (broken ? 'row-bad' : '') + '">' +
+        '<td>' + e.seq + '</td>' +
+        '<td>' + esc((e.timestamp || '').replace('T', ' ').replace(/\..*/, '')) + '</td>' +
+        '<td>' + eventSummary(e) + '</td>' +
+        '<td class="mono">' + esc(String(e.hash).slice(0, 12)) + '…</td>' +
+        '</tr>';
+    }).join('');
+    document.getElementById('integrity-log').innerHTML =
+      '<table><thead><tr><th>#</th><th>When</th><th>Action</th><th>Hash</th></tr></thead><tbody>' +
+      rows + '</tbody></table>';
+  }
+
+  // --- backup / restore (continuity of the legal record) ---
+  document.getElementById('btn-backup').addEventListener('click', function () {
+    var backup = INT.makeBackup(log, nowIso());
+    var blob = new Blob([JSON.stringify(backup, null, 2)], { type: 'application/json' });
+    var url = URL.createObjectURL(blob);
+    var a = document.createElement('a');
+    a.href = url;
+    a.download = 'bound-book-backup.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  });
+
+  var restoreInput = document.getElementById('restore-input');
+  restoreInput.addEventListener('change', function () {
+    var file = this.files && this.files[0];
+    var msg = document.getElementById('restore-msg');
+    if (!file) return;
+    var reader = new FileReader();
+    reader.onload = function () {
+      var res = INT.parseBackup(String(reader.result));
+      if (!res.ok) {
+        msg.innerHTML = '<div class="chain-bad">' + esc(res.error) + '</div>';
+        restoreInput.value = '';
+        return;
+      }
+      if (log.length && !window.confirm('Restore ' + res.log.length + ' entries from this backup? This replaces the current record on this device.')) {
+        restoreInput.value = '';
+        return;
+      }
+      log = res.log;
+      saveLog();
+      entries = INT.project(log);
+      restoreInput.value = '';
+      msg.innerHTML = '<div class="chain-ok">Restored ' + res.log.length + ' entries. Chain verified.</div>';
+      renderIntegrity();
+    };
+    reader.readAsText(file);
+  });
+
+  // --- profile ---
+  (function initProfile() {
+    var form = document.getElementById('profile-form');
+    var p = loadProfile();
+    ['name', 'ffl', 'address'].forEach(function (k) { if (form[k]) form[k].value = p[k] || ''; });
+    form.addEventListener('submit', function (ev) {
+      ev.preventDefault();
+      saveProfile(formData(this));
+      document.getElementById('profile-saved').textContent = 'Saved.';
+      setTimeout(function () { document.getElementById('profile-saved').textContent = ''; }, 1500);
+    });
+  })();
+
+  // --- disclaimer ---
+  (function initDisclaimer() {
+    if (localStorage.getItem(DISCLAIMER_KEY)) return;
+    var modal = document.getElementById('disclaimer');
+    modal.classList.remove('hidden');
+    var ack = document.getElementById('disclaimer-ack');
+    var ok = document.getElementById('disclaimer-ok');
+    ack.addEventListener('change', function () { ok.disabled = !ack.checked; });
+    ok.addEventListener('click', function () {
+      localStorage.setItem(DISCLAIMER_KEY, '1');
+      modal.classList.add('hidden');
+    });
+  })();
+
+  show('acquire');
+})();

--- a/apps/bound-book/core.js
+++ b/apps/bound-book/core.js
@@ -1,0 +1,196 @@
+// core.js — pure, storage-agnostic logic for the Bound Book budget tier.
+// Runs in the browser (attached to window.BoundBook) and under Node (require) for tests.
+// No Date/random defaults inside pure functions: callers pass ids and timestamps
+// so behavior is deterministic and testable.
+
+(function (root, factory) {
+  if (typeof module === 'object' && module.exports) module.exports = factory();
+  else root.BoundBook = factory();
+})(typeof self !== 'undefined' ? self : this, function () {
+  'use strict';
+
+  // ATF-required fields per firearm (27 CFR Part 478). Labels are used by the UI
+  // and the ledger export headers.
+  var ACQ_FIELDS = [
+    { key: 'dateReceived', label: 'Date received' },
+    { key: 'mfrImporter', label: 'Manufacturer / Importer' },
+    { key: 'model', label: 'Model' },
+    { key: 'serial', label: 'Serial number' },
+    { key: 'type', label: 'Type' },
+    { key: 'caliber', label: 'Caliber / Gauge' }
+  ];
+
+  var DISP_FIELDS = [
+    { key: 'date', label: 'Date of disposition' },
+    { key: 'formSerial', label: '4473 / transfer reference' },
+    { key: 'eligibilityNote', label: 'Eligibility documentation' }
+  ];
+
+  function isBlank(v) {
+    return v === undefined || v === null || String(v).trim() === '';
+  }
+
+  // A source/buyer is valid if we have (name AND address) OR an FFL number.
+  function partyValid(name, address, ffl) {
+    return (!isBlank(name) && !isBlank(address)) || !isBlank(ffl);
+  }
+
+  function validateAcquisition(a) {
+    a = a || {};
+    var errors = [];
+    ACQ_FIELDS.forEach(function (f) {
+      if (isBlank(a[f.key])) errors.push(f.label + ' is required.');
+    });
+    if (!partyValid(a.sourceName, a.sourceAddress, a.sourceFfl)) {
+      errors.push('Source requires either name + address, or an FFL number.');
+    }
+    return { ok: errors.length === 0, errors: errors };
+  }
+
+  function validateDisposition(d) {
+    d = d || {};
+    var errors = [];
+    DISP_FIELDS.forEach(function (f) {
+      if (isBlank(d[f.key])) errors.push(f.label + ' is required.');
+    });
+    if (!partyValid(d.buyerName, d.buyerAddress, d.buyerFfl)) {
+      errors.push('Buyer/transferee requires either name + address, or an FFL number.');
+    }
+    return { ok: errors.length === 0, errors: errors };
+  }
+
+  // Build a new open entry. Caller supplies id and createdAt (ISO string).
+  function newEntry(acq, id, createdAt) {
+    return {
+      id: id,
+      createdAt: createdAt,
+      status: 'open',
+      acquisition: {
+        dateReceived: acq.dateReceived,
+        mfrImporter: acq.mfrImporter,
+        model: acq.model,
+        serial: acq.serial,
+        type: acq.type,
+        caliber: acq.caliber,
+        sourceName: acq.sourceName || '',
+        sourceAddress: acq.sourceAddress || '',
+        sourceFfl: acq.sourceFfl || ''
+      },
+      disposition: null,
+      corrections: []
+    };
+  }
+
+  // Record a disposition against an open entry. Returns a new entry object.
+  function applyDisposition(entry, disp) {
+    var next = clone(entry);
+    next.disposition = {
+      date: disp.date,
+      buyerName: disp.buyerName || '',
+      buyerAddress: disp.buyerAddress || '',
+      buyerFfl: disp.buyerFfl || '',
+      formSerial: disp.formSerial,
+      eligibilityNote: disp.eligibilityNote
+    };
+    next.status = 'disposed';
+    return next;
+  }
+
+  // Append-only correction. Original field values are never mutated in place;
+  // the "line-out, don't erase" convention is preserved by keeping the history.
+  // `path` is a dotted path, e.g. 'acquisition.serial'.
+  function addCorrection(entry, path, newValue, reason, at) {
+    var next = clone(entry);
+    next.corrections = next.corrections.concat([{
+      field: path,
+      oldValue: currentValue(entry, path),
+      newValue: newValue,
+      reason: reason,
+      at: at
+    }]);
+    return next;
+  }
+
+  // Effective value of a field = latest correction for that path, else the
+  // original stored value.
+  function currentValue(entry, path) {
+    var latest;
+    for (var i = 0; i < entry.corrections.length; i++) {
+      if (entry.corrections[i].field === path) latest = entry.corrections[i];
+    }
+    if (latest) return latest.newValue;
+    return getPath(entry, path);
+  }
+
+  function getPath(obj, path) {
+    return path.split('.').reduce(function (o, k) {
+      return o == null ? undefined : o[k];
+    }, obj);
+  }
+
+  function clone(o) {
+    return JSON.parse(JSON.stringify(o));
+  }
+
+  // --- CSV export (backup format) ---
+
+  function csvEscape(v) {
+    var s = v == null ? '' : String(v);
+    if (/[",\n\r]/.test(s)) return '"' + s.replace(/"/g, '""') + '"';
+    return s;
+  }
+
+  var CSV_COLUMNS = [
+    { header: 'Entry ID', get: function (e) { return e.id; } },
+    { header: 'Status', get: function (e) { return e.status; } },
+    { header: 'Date received', get: function (e) { return cv(e, 'acquisition.dateReceived'); } },
+    { header: 'Manufacturer/Importer', get: function (e) { return cv(e, 'acquisition.mfrImporter'); } },
+    { header: 'Model', get: function (e) { return cv(e, 'acquisition.model'); } },
+    { header: 'Serial', get: function (e) { return cv(e, 'acquisition.serial'); } },
+    { header: 'Type', get: function (e) { return cv(e, 'acquisition.type'); } },
+    { header: 'Caliber/Gauge', get: function (e) { return cv(e, 'acquisition.caliber'); } },
+    { header: 'Source', get: function (e) { return party(e, 'source'); } },
+    { header: 'Disposition date', get: function (e) { return e.disposition ? cv(e, 'disposition.date') : ''; } },
+    { header: 'Buyer/Transferee', get: function (e) { return e.disposition ? party(e, 'buyer') : ''; } },
+    { header: '4473/Transfer ref', get: function (e) { return e.disposition ? cv(e, 'disposition.formSerial') : ''; } },
+    { header: 'Eligibility doc', get: function (e) { return e.disposition ? cv(e, 'disposition.eligibilityNote') : ''; } }
+  ];
+
+  function cv(e, path) {
+    var v = currentValue(e, path);
+    return v == null ? '' : v;
+  }
+
+  // Render a party ('source' or 'buyer') as "name, address" or "FFL# ...".
+  function party(e, which) {
+    var prefix = which === 'source' ? 'acquisition.source' : 'disposition.buyer';
+    var name = cv(e, prefix + 'Name');
+    var addr = cv(e, prefix + 'Address');
+    var ffl = cv(e, prefix + 'Ffl');
+    if (name || addr) return [name, addr].filter(Boolean).join(', ');
+    return ffl ? 'FFL# ' + ffl : '';
+  }
+
+  function toCSV(entries) {
+    var lines = [CSV_COLUMNS.map(function (c) { return csvEscape(c.header); }).join(',')];
+    entries.forEach(function (e) {
+      lines.push(CSV_COLUMNS.map(function (c) { return csvEscape(c.get(e)); }).join(','));
+    });
+    return lines.join('\r\n');
+  }
+
+  return {
+    ACQ_FIELDS: ACQ_FIELDS,
+    DISP_FIELDS: DISP_FIELDS,
+    validateAcquisition: validateAcquisition,
+    validateDisposition: validateDisposition,
+    newEntry: newEntry,
+    applyDisposition: applyDisposition,
+    addCorrection: addCorrection,
+    currentValue: currentValue,
+    party: party,
+    toCSV: toCSV,
+    csvEscape: csvEscape,
+    CSV_COLUMNS: CSV_COLUMNS
+  };
+});

--- a/apps/bound-book/core.test.js
+++ b/apps/bound-book/core.test.js
@@ -1,0 +1,100 @@
+// Run: node --test  (from apps/bound-book/)
+const test = require('node:test');
+const assert = require('node:assert');
+const BB = require('./core.js');
+
+const goodAcq = {
+  dateReceived: '2026-07-24',
+  mfrImporter: 'Acme Arms',
+  model: 'M1',
+  serial: 'SN123',
+  type: 'Pistol',
+  caliber: '9mm',
+  sourceName: 'Distributor LLC',
+  sourceAddress: '1 Main St'
+};
+
+test('validateAcquisition passes with all required fields', () => {
+  assert.deepEqual(BB.validateAcquisition(goodAcq), { ok: true, errors: [] });
+});
+
+test('validateAcquisition flags each missing required field', () => {
+  const res = BB.validateAcquisition({});
+  assert.equal(res.ok, false);
+  // 6 required scalar fields + 1 party error
+  assert.equal(res.errors.length, 7);
+});
+
+test('source is valid via FFL number alone (no name/address)', () => {
+  const acq = Object.assign({}, goodAcq, { sourceName: '', sourceAddress: '', sourceFfl: '1-23-45' });
+  assert.equal(BB.validateAcquisition(acq).ok, true);
+});
+
+test('source with only a name (no address, no FFL) is invalid', () => {
+  const acq = Object.assign({}, goodAcq, { sourceName: 'Bob', sourceAddress: '', sourceFfl: '' });
+  const res = BB.validateAcquisition(acq);
+  assert.equal(res.ok, false);
+  assert.ok(res.errors.some((e) => /Source requires/.test(e)));
+});
+
+test('validateDisposition requires buyer, form serial, eligibility', () => {
+  const res = BB.validateDisposition({});
+  assert.equal(res.ok, false);
+  assert.ok(res.errors.length >= 4);
+});
+
+test('applyDisposition sets status and does not mutate the original', () => {
+  const e = BB.newEntry(goodAcq, 'id1', '2026-07-24T00:00:00Z');
+  const disposed = BB.applyDisposition(e, {
+    date: '2026-07-25', buyerName: 'Jane', buyerAddress: '2 Oak',
+    formSerial: 'F900', eligibilityNote: '4473 on file, box 3'
+  });
+  assert.equal(disposed.status, 'disposed');
+  assert.equal(e.status, 'open', 'original entry unchanged');
+  assert.equal(disposed.disposition.buyerName, 'Jane');
+});
+
+test('addCorrection is append-only and currentValue reflects latest', () => {
+  const e = BB.newEntry(goodAcq, 'id1', '2026-07-24T00:00:00Z');
+  assert.equal(BB.currentValue(e, 'acquisition.serial'), 'SN123');
+
+  const c1 = BB.addCorrection(e, 'acquisition.serial', 'SN999', 'typo', '2026-07-24T01:00:00Z');
+  // original object still shows original stored value
+  assert.equal(e.acquisition.serial, 'SN123');
+  assert.equal(c1.acquisition.serial, 'SN123', 'stored value never overwritten');
+  assert.equal(BB.currentValue(c1, 'acquisition.serial'), 'SN999');
+  assert.equal(c1.corrections.length, 1);
+  assert.equal(c1.corrections[0].oldValue, 'SN123');
+
+  const c2 = BB.addCorrection(c1, 'acquisition.serial', 'SN000', 'again', '2026-07-24T02:00:00Z');
+  assert.equal(BB.currentValue(c2, 'acquisition.serial'), 'SN000');
+  assert.equal(c2.corrections.length, 2);
+  assert.equal(c2.corrections[1].oldValue, 'SN999', 'correction chains from prior current value');
+});
+
+test('csvEscape quotes commas, quotes, and newlines', () => {
+  assert.equal(BB.csvEscape('plain'), 'plain');
+  assert.equal(BB.csvEscape('a,b'), '"a,b"');
+  assert.equal(BB.csvEscape('say "hi"'), '"say ""hi"""');
+  assert.equal(BB.csvEscape('line1\nline2'), '"line1\nline2"');
+});
+
+test('toCSV emits header plus one row per entry with a party rendered', () => {
+  const e1 = BB.newEntry(goodAcq, 'id1', '2026-07-24T00:00:00Z');
+  const e2 = BB.applyDisposition(
+    BB.newEntry(Object.assign({}, goodAcq, { serial: 'SN2' }), 'id2', '2026-07-24T00:00:00Z'),
+    { date: '2026-07-25', buyerName: 'Jane', buyerAddress: '2 Oak', formSerial: 'F900', eligibilityNote: 'box 3' }
+  );
+  const csv = BB.toCSV([e1, e2]);
+  const lines = csv.split('\r\n');
+  assert.equal(lines.length, 3);
+  assert.ok(lines[0].startsWith('Entry ID,Status,'));
+  assert.ok(lines[1].includes('Distributor LLC, 1 Main St'));
+  assert.ok(lines[2].includes('Jane, 2 Oak'));
+});
+
+test('party renders FFL form when no name/address', () => {
+  const acq = Object.assign({}, goodAcq, { sourceName: '', sourceAddress: '', sourceFfl: '1-23-45' });
+  const e = BB.newEntry(acq, 'id1', '2026-07-24T00:00:00Z');
+  assert.equal(BB.party(e, 'source'), 'FFL# 1-23-45');
+});

--- a/apps/bound-book/index.html
+++ b/apps/bound-book/index.html
@@ -1,0 +1,160 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Bound Book — A&amp;D Record</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <!-- First-run disclaimer -->
+  <div id="disclaimer" class="modal hidden">
+    <div class="modal-card">
+      <h2>Before you start</h2>
+      <p>This tool keeps your Acquisition &amp; Disposition record as a tamper-evident,
+         hash-linked log — <strong>your electronic system of record</strong> (ATF variance
+         on file). Nothing is edited in place; corrections are logged.</p>
+      <p><strong>Back up regularly.</strong> Use <em>Integrity → Download full backup</em>
+         to keep a current copy — that copy is your continuity and your surrender copy.</p>
+      <p>This is not legal advice. Confirm ATF requirements (27 CFR Part 478) and any
+         state rules for your situation.</p>
+      <label class="check"><input type="checkbox" id="disclaimer-ack" /> I understand.</label>
+      <button id="disclaimer-ok" disabled>Continue</button>
+    </div>
+  </div>
+
+  <header class="topbar no-print">
+    <div class="brand">Bound Book <span class="tag">budget</span></div>
+    <nav>
+      <button data-view="acquire" class="active">Acquire</button>
+      <button data-view="dispose">Dispose</button>
+      <button data-view="ledger">Ledger</button>
+      <button data-view="export">Export / Print</button>
+      <button data-view="integrity">Integrity</button>
+      <button data-view="profile">Licensee</button>
+    </nav>
+  </header>
+
+  <main>
+    <!-- ACQUIRE -->
+    <section id="view-acquire" class="view">
+      <h1>Log an acquisition</h1>
+      <p class="hint">Record a firearm coming in. All fields are required by ATF; source
+        needs either a name + address, or an FFL number.</p>
+      <form id="acquire-form" class="grid">
+        <label>Date received<input name="dateReceived" type="date" required /></label>
+        <label>Manufacturer / Importer<input name="mfrImporter" required /></label>
+        <label>Model<input name="model" required /></label>
+        <label>Serial number<input name="serial" required /></label>
+        <label>Type<input name="type" placeholder="Pistol, Rifle, Receiver…" required /></label>
+        <label>Caliber / Gauge<input name="caliber" required /></label>
+        <fieldset class="span2">
+          <legend>Source</legend>
+          <label>Name<input name="sourceName" /></label>
+          <label>Address<input name="sourceAddress" /></label>
+          <label>or FFL #<input name="sourceFfl" placeholder="if from a licensee" /></label>
+        </fieldset>
+        <div class="errors span2" id="acquire-errors"></div>
+        <button type="submit" class="span2">Add acquisition</button>
+      </form>
+    </section>
+
+    <!-- DISPOSE -->
+    <section id="view-dispose" class="view hidden">
+      <h1>Log a disposition</h1>
+      <p class="hint">Pick an open firearm, then record where it went.</p>
+      <label class="pick">Open firearm
+        <select id="dispose-select"></select>
+      </label>
+      <form id="dispose-form" class="grid">
+        <label>Date of disposition<input name="date" type="date" required /></label>
+        <label>4473 / transfer reference<input name="formSerial" required /></label>
+        <fieldset class="span2">
+          <legend>Buyer / Transferee</legend>
+          <label>Name<input name="buyerName" /></label>
+          <label>Address<input name="buyerAddress" /></label>
+          <label>or FFL #<input name="buyerFfl" /></label>
+        </fieldset>
+        <label class="span2">Eligibility documentation
+          <input name="eligibilityNote" placeholder="e.g. 4473 + NICS proceed on file, binder A" required />
+        </label>
+        <div class="errors span2" id="dispose-errors"></div>
+        <button type="submit" class="span2">Record disposition</button>
+      </form>
+    </section>
+
+    <!-- LEDGER -->
+    <section id="view-ledger" class="view hidden">
+      <h1>Ledger</h1>
+      <input id="ledger-search" class="no-print" placeholder="Search serial, model, name, FFL…" />
+      <div id="ledger-table"></div>
+    </section>
+
+    <!-- EXPORT -->
+    <section id="view-export" class="view hidden">
+      <h1>Export &amp; print</h1>
+      <p class="hint">The printout / PDF is your official bound book. The CSV is your backup.</p>
+      <div class="actions no-print">
+        <button id="btn-print">Print / Save as PDF</button>
+        <button id="btn-csv">Download CSV backup</button>
+      </div>
+      <div id="print-ledger"></div>
+    </section>
+
+    <!-- INTEGRITY -->
+    <section id="view-integrity" class="view hidden">
+      <h1>Record integrity</h1>
+      <p class="hint">Every action is an entry in an append-only, hash-linked log.
+        Editing or removing anything after the fact breaks the chain and is flagged here.</p>
+      <div id="integrity-status"></div>
+      <p class="hint" style="margin-top:1rem">This log is your electronic system of record (ATF variance on file).
+        Keep a current backup — it is your continuity copy and your surrender copy if the license ends.</p>
+      <div class="actions no-print">
+        <button id="btn-backup">Download full backup (.json)</button>
+        <label class="restore-btn">Restore from backup…
+          <input type="file" id="restore-input" accept="application/json,.json" hidden />
+        </label>
+      </div>
+      <div id="restore-msg"></div>
+      <div id="integrity-log"></div>
+    </section>
+
+    <!-- PROFILE -->
+    <section id="view-profile" class="view hidden">
+      <h1>Licensee details</h1>
+      <p class="hint">Used as the header on your printed ledger.</p>
+      <form id="profile-form" class="grid">
+        <label>Licensee / Business name<input name="name" /></label>
+        <label>FFL number<input name="ffl" /></label>
+        <label class="span2">Premises address<input name="address" /></label>
+        <button type="submit" class="span2">Save</button>
+        <span id="profile-saved" class="saved span2"></span>
+      </form>
+    </section>
+  </main>
+
+  <!-- Correction modal (append-only; original values are never erased) -->
+  <div id="correct-modal" class="modal hidden">
+    <div class="modal-card">
+      <h2>Log a correction</h2>
+      <p class="hint" id="correct-target"></p>
+      <form id="correct-form" class="grid">
+        <label class="span2">Field
+          <select name="field" id="correct-field"></select>
+        </label>
+        <label class="span2">Corrected value<input name="newValue" required /></label>
+        <label class="span2">Reason<input name="reason" placeholder="e.g. transcription error" required /></label>
+        <div class="errors span2" id="correct-errors"></div>
+        <div class="actions span2">
+          <button type="submit">Save correction</button>
+          <button type="button" id="correct-cancel">Cancel</button>
+        </div>
+      </form>
+    </div>
+  </div>
+
+  <script src="core.js"></script>
+  <script src="integrity.js"></script>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/apps/bound-book/index.html
+++ b/apps/bound-book/index.html
@@ -127,6 +127,13 @@
         <label>Licensee / Business name<input name="name" /></label>
         <label>FFL number<input name="ffl" /></label>
         <label class="span2">Premises address<input name="address" /></label>
+        <fieldset class="span2">
+          <legend>Backup policy</legend>
+          <label>Remind me to back up every (days)
+            <input name="backupIntervalDays" type="number" min="0" step="1" placeholder="30" />
+          </label>
+          <p class="hint span2" style="margin:0.3rem 0 0">Set this to your variance's required backup cadence. 0 turns the time-based reminder off. Moving a copy offsite is still a manual step this app can't do for you.</p>
+        </fieldset>
         <button type="submit" class="span2">Save</button>
         <span id="profile-saved" class="saved span2"></span>
       </form>

--- a/apps/bound-book/index.html
+++ b/apps/bound-book/index.html
@@ -28,6 +28,7 @@
     <nav>
       <button data-view="acquire" class="active">Acquire</button>
       <button data-view="dispose">Dispose</button>
+      <button data-view="packages">Packages</button>
       <button data-view="ledger">Ledger</button>
       <button data-view="export">Export / Print</button>
       <button data-view="integrity">Integrity</button>
@@ -41,6 +42,7 @@
       <h1>Log an acquisition</h1>
       <p class="hint">Record a firearm coming in. All fields are required by ATF; source
         needs either a name + address, or an FFL number.</p>
+      <div id="acquire-from-package" class="pkg-banner hidden"></div>
       <form id="acquire-form" class="grid">
         <label>Date received<input name="dateReceived" type="date" required /></label>
         <label>Manufacturer / Importer<input name="mfrImporter" required /></label>
@@ -81,6 +83,54 @@
         <div class="errors span2" id="dispose-errors"></div>
         <button type="submit" class="span2">Record disposition</button>
       </form>
+    </section>
+
+    <!-- PACKAGES -->
+    <section id="view-packages" class="view hidden">
+      <h1>Inbound packages</h1>
+      <p class="hint">What is on its way here, and what has arrived but is not yet in the
+        bound book. Status comes from the carriers themselves, not from your email.</p>
+      <p class="hint"><strong>This screen is not part of the A&amp;D record.</strong> It is a
+        working list: carrier data is not a regulated field and never enters the hash-chained
+        log. The only thing that reaches your legal record is an acquisition you log yourself.</p>
+
+      <div id="packages-alerts"></div>
+
+      <div class="actions no-print">
+        <button id="btn-tracking-list">Download tracking list (.json)</button>
+        <label class="restore-btn">Import snapshot&hellip;
+          <input type="file" id="snapshot-input" accept="application/json,.json" hidden />
+        </label>
+      </div>
+      <div id="snapshot-msg"></div>
+      <p class="hint">Run <span class="mono">node poll.js poll --list tracking-list.json</span>
+        in <span class="mono">tracker/</span> between those two steps. See
+        <span class="mono">tracker/README.md</span> for first-time setup.</p>
+
+      <details id="package-add">
+        <summary>Add an expected package</summary>
+        <form id="package-form" class="grid">
+          <label class="span2">What are you expecting?
+            <input name="description" placeholder="e.g. Glock 19 from Acme Distributors" required />
+          </label>
+          <label>Tracking number
+            <input name="trackingNumber" placeholder="optional — add it when you have it" />
+          </label>
+          <label>Carrier
+            <select name="carrier">
+              <option value="">Detect from the number</option>
+              <option value="usps">USPS</option>
+              <option value="ups">UPS</option>
+              <option value="fedex">FedEx</option>
+            </select>
+          </label>
+          <label>Expected by<input name="expectedBy" type="date" /></label>
+          <div class="errors span2" id="package-errors"></div>
+          <button type="submit" class="span2">Add to the list</button>
+        </form>
+      </details>
+
+      <div id="packages-table"></div>
     </section>
 
     <!-- LEDGER -->
@@ -162,6 +212,7 @@
 
   <script src="core.js"></script>
   <script src="integrity.js"></script>
+  <script src="packages.js"></script>
   <script src="app.js"></script>
 </body>
 </html>

--- a/apps/bound-book/integrity.js
+++ b/apps/bound-book/integrity.js
@@ -188,6 +188,27 @@
     return { ok: true, log: data.log };
   }
 
+  // The seq of the last event, or 0 for an empty log. Used as the backup marker.
+  function headSeq(log) {
+    return log.length ? log[log.length - 1].seq : 0;
+  }
+
+  // How current the last backup is. `lastBackup` is the stored marker
+  // { seq, at } from the most recent Download, or null if never backed up.
+  // `pending` counts events recorded since that backup — any of them would be
+  // lost if this machine were lost, so a non-zero count is a continuity risk.
+  function backupStatus(log, lastBackup) {
+    var head = headSeq(log);
+    var backedSeq = lastBackup ? lastBackup.seq : 0;
+    var pending = Math.max(0, head - backedSeq);
+    return {
+      pending: pending,
+      upToDate: pending === 0,
+      neverBackedUp: !lastBackup && head > 0,
+      lastBackupAt: lastBackup ? lastBackup.at : null
+    };
+  }
+
   return {
     GENESIS: GENESIS,
     sha256: sha256,
@@ -197,6 +218,8 @@
     verifyChain: verifyChain,
     project: project,
     makeBackup: makeBackup,
-    parseBackup: parseBackup
+    parseBackup: parseBackup,
+    headSeq: headSeq,
+    backupStatus: backupStatus
   };
 });

--- a/apps/bound-book/integrity.js
+++ b/apps/bound-book/integrity.js
@@ -1,0 +1,202 @@
+// integrity.js — the "toward Option B" layer: an append-only, hash-chained
+// event log that gives the record tamper-evidence, guaranteed no-gaps, and a
+// full audit trail. State (the ledger) is a projection of this event log.
+//
+// This provides the TECHNICAL properties an electronic system of record needs.
+// It does NOT by itself make the app your sole legal ATF record — that still
+// requires ATF approval (a variance). See the PRD.
+//
+// Depends on BoundBook (core.js) for entry semantics. Runs in browser
+// (window.Integrity) and Node (require) for tests.
+
+(function (root, factory) {
+  var core = (typeof module === 'object' && module.exports) ? require('./core.js') : root.BoundBook;
+  var mod = factory(core);
+  if (typeof module === 'object' && module.exports) module.exports = mod;
+  else root.Integrity = mod;
+})(typeof self !== 'undefined' ? self : this, function (BB) {
+  'use strict';
+
+  var GENESIS = 'GENESIS';
+
+  // --- SHA-256 (compact, synchronous, dependency-free) ---
+  // Sync + no crypto.subtle so it works from file:// by double-click and in Node.
+  function sha256(ascii) {
+    function rightRotate(value, amount) { return (value >>> amount) | (value << (32 - amount)); }
+    var maxWord = Math.pow(2, 32);
+    var result = '';
+    var words = [];
+    var asciiBitLength = ascii.length * 8;
+
+    var hash = sha256.h = sha256.h || [];
+    var k = sha256.k = sha256.k || [];
+    var primeCounter = k.length;
+
+    var isComposite = {};
+    for (var candidate = 2; primeCounter < 64; candidate++) {
+      if (!isComposite[candidate]) {
+        for (var i = 0; i < 313; i += candidate) { isComposite[i] = candidate; }
+        hash[primeCounter] = (Math.pow(candidate, 0.5) * maxWord) | 0;
+        k[primeCounter++] = (Math.pow(candidate, 1 / 3) * maxWord) | 0;
+      }
+    }
+
+    ascii += '\x80';
+    while (ascii.length % 64 - 56) ascii += '\x00';
+    for (i = 0; i < ascii.length; i++) {
+      var j = ascii.charCodeAt(i);
+      if (j >> 8) throw new Error('sha256 expects a byte string');
+      words[i >> 2] |= j << ((3 - i) % 4) * 8;
+    }
+    words[words.length] = (asciiBitLength / maxWord) | 0;
+    words[words.length] = asciiBitLength;
+
+    for (j = 0; j < words.length;) {
+      var w = words.slice(j, j += 16);
+      var oldHash = hash;
+      hash = hash.slice(0, 8);
+
+      for (i = 0; i < 64; i++) {
+        var w15 = w[i - 15], w2 = w[i - 2];
+        var a = hash[0], e = hash[4];
+        var temp1 = hash[7]
+          + (rightRotate(e, 6) ^ rightRotate(e, 11) ^ rightRotate(e, 25))
+          + ((e & hash[5]) ^ ((~e) & hash[6]))
+          + k[i]
+          + (w[i] = i < 16 ? w[i] : (
+              w[i - 16]
+              + (rightRotate(w15, 7) ^ rightRotate(w15, 18) ^ (w15 >>> 3))
+              + w[i - 7]
+              + (rightRotate(w2, 17) ^ rightRotate(w2, 19) ^ (w2 >>> 10))
+            ) | 0
+          );
+        var temp2 = (rightRotate(a, 2) ^ rightRotate(a, 13) ^ rightRotate(a, 22))
+          + ((a & hash[1]) ^ (a & hash[2]) ^ (hash[1] & hash[2]));
+        hash = [(temp1 + temp2) | 0].concat(hash);
+        hash[4] = (hash[4] + temp1) | 0;
+      }
+
+      for (i = 0; i < 8; i++) { hash[i] = (hash[i] + oldHash[i]) | 0; }
+    }
+
+    for (i = 0; i < 8; i++) {
+      for (j = 3; j + 1; j--) {
+        var b = (hash[i] >> (j * 8)) & 255;
+        result += ((b < 16) ? 0 : '') + b.toString(16);
+      }
+    }
+    return result;
+  }
+
+  // Hash any (unicode) string by first encoding to a UTF-8 byte string.
+  function hashString(str) {
+    var bytes = new TextEncoder().encode(str);
+    var bin = '';
+    for (var i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
+    return sha256(bin);
+  }
+
+  // Hash of an event's signed fields (everything except its own hash).
+  function hashEvent(evt) {
+    return hashString(JSON.stringify([evt.seq, evt.type, evt.payload, evt.timestamp, evt.prevHash]));
+  }
+
+  // Append a new event, chaining it to the previous one. Returns a NEW log.
+  function appendEvent(log, type, payload, timestamp) {
+    var prev = log.length ? log[log.length - 1] : null;
+    var evt = {
+      seq: prev ? prev.seq + 1 : 1,
+      type: type,
+      // Snapshot the payload so the log owns an immutable copy the caller can't
+      // later mutate out from under the hash.
+      payload: JSON.parse(JSON.stringify(payload)),
+      timestamp: timestamp,
+      prevHash: prev ? prev.hash : GENESIS
+    };
+    evt.hash = hashEvent(evt);
+    return log.concat([evt]);
+  }
+
+  // Walk the chain: sequence must be 1..N with no gaps/reorders, each link must
+  // point at the prior hash, and each event's content must re-hash to its stored
+  // hash. Returns the first break found, or ok with a count.
+  function verifyChain(log) {
+    var prevHash = GENESIS;
+    for (var i = 0; i < log.length; i++) {
+      var e = log[i];
+      if (e.seq !== i + 1) {
+        return { ok: false, brokenAt: i + 1, reason: 'Sequence gap or reorder at position ' + (i + 1) + '.' };
+      }
+      if (e.prevHash !== prevHash) {
+        return { ok: false, brokenAt: e.seq, reason: 'Broken chain link at entry #' + e.seq + ' (a prior entry was altered or removed).' };
+      }
+      if (hashEvent(e) !== e.hash) {
+        return { ok: false, brokenAt: e.seq, reason: 'Altered content at entry #' + e.seq + '.' };
+      }
+      prevHash = e.hash;
+    }
+    return { ok: true, count: log.length };
+  }
+
+  // Fold the event log into the current ledger (array of entries). Entry shape
+  // matches core.js so all existing rendering/export works unchanged.
+  function project(log) {
+    var byId = {};
+    var order = [];
+    log.forEach(function (e) {
+      var id;
+      if (e.type === 'acquire') {
+        var entry = BB.newEntry(e.payload, e.payload.entryId, e.timestamp);
+        byId[entry.id] = entry;
+        order.push(entry.id);
+      } else if (e.type === 'dispose') {
+        id = e.payload.entryId;
+        if (byId[id]) byId[id] = BB.applyDisposition(byId[id], e.payload);
+      } else if (e.type === 'correct') {
+        id = e.payload.entryId;
+        if (byId[id]) byId[id] = BB.addCorrection(byId[id], e.payload.field, e.payload.newValue, e.payload.reason, e.timestamp);
+      }
+    });
+    return order.map(function (id) { return byId[id]; });
+  }
+
+  // --- backup / continuity ---
+  // Full-fidelity backup: the entire event log, wrapped in a small versioned
+  // envelope. This is the record's continuity + surrender copy; unlike CSV it
+  // preserves the hash chain so integrity can be re-verified after a restore.
+  var BACKUP_APP = 'bound-book';
+  var BACKUP_VERSION = 1;
+
+  function makeBackup(log, exportedAt) {
+    return { app: BACKUP_APP, version: BACKUP_VERSION, exportedAt: exportedAt, log: log };
+  }
+
+  // Parse and validate a backup file's text. Returns { ok, log } on success, or
+  // { ok:false, error } — including when the restored chain fails verification,
+  // so a tampered/corrupt backup is never silently loaded as the legal record.
+  function parseBackup(text) {
+    var data;
+    try { data = JSON.parse(text); }
+    catch (e) { return { ok: false, error: 'Not a valid backup file (could not read JSON).' }; }
+    if (!data || data.app !== BACKUP_APP || !Array.isArray(data.log)) {
+      return { ok: false, error: 'This does not look like a Bound Book backup.' };
+    }
+    var check = verifyChain(data.log);
+    if (!check.ok) {
+      return { ok: false, error: 'Backup failed the integrity check and was not loaded. ' + check.reason };
+    }
+    return { ok: true, log: data.log };
+  }
+
+  return {
+    GENESIS: GENESIS,
+    sha256: sha256,
+    hashString: hashString,
+    hashEvent: hashEvent,
+    appendEvent: appendEvent,
+    verifyChain: verifyChain,
+    project: project,
+    makeBackup: makeBackup,
+    parseBackup: parseBackup
+  };
+});

--- a/apps/bound-book/integrity.js
+++ b/apps/bound-book/integrity.js
@@ -209,6 +209,19 @@
     };
   }
 
+  // Time-based backup policy. Given the last-backup marker { seq, at }, the
+  // current time, and the licensee's required interval (days), report whether a
+  // fresh backup is due by the calendar — the complement to the change-based
+  // check in backupStatus(). Deterministic: the caller passes `nowIso`.
+  var DAY_MS = 86400000;
+  function backupOverdue(lastBackup, nowIso, intervalDays) {
+    if (!lastBackup || !lastBackup.at || !(intervalDays > 0)) {
+      return { overdue: false, ageDays: null };
+    }
+    var ageDays = Math.floor((new Date(nowIso).getTime() - new Date(lastBackup.at).getTime()) / DAY_MS);
+    return { overdue: ageDays >= intervalDays, ageDays: ageDays };
+  }
+
   return {
     GENESIS: GENESIS,
     sha256: sha256,
@@ -220,6 +233,7 @@
     makeBackup: makeBackup,
     parseBackup: parseBackup,
     headSeq: headSeq,
-    backupStatus: backupStatus
+    backupStatus: backupStatus,
+    backupOverdue: backupOverdue
   };
 });

--- a/apps/bound-book/integrity.test.js
+++ b/apps/bound-book/integrity.test.js
@@ -1,0 +1,123 @@
+// Run: node --test  (from apps/bound-book/)
+const test = require('node:test');
+const assert = require('node:assert');
+const I = require('./integrity.js');
+
+const acq = {
+  entryId: 'e1', dateReceived: '2026-07-24', mfrImporter: 'Acme', model: 'M1',
+  serial: 'SN123', type: 'Pistol', caliber: '9mm', sourceName: 'Dist', sourceAddress: '1 Main'
+};
+
+test('sha256 matches known NIST test vectors', () => {
+  assert.equal(I.hashString(''), 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855');
+  assert.equal(I.hashString('abc'), 'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad');
+});
+
+test('hashString handles unicode (UTF-8 encoded)', () => {
+  // must not throw, and must be a 64-hex-char digest
+  const h = I.hashString('José — café ☕');
+  assert.match(h, /^[0-9a-f]{64}$/);
+});
+
+function buildLog() {
+  let log = [];
+  log = I.appendEvent(log, 'acquire', acq, '2026-07-24T00:00:00Z');
+  log = I.appendEvent(log, 'acquire', Object.assign({}, acq, { entryId: 'e2', serial: 'SN2' }), '2026-07-24T01:00:00Z');
+  log = I.appendEvent(log, 'dispose', {
+    entryId: 'e1', date: '2026-07-25', buyerName: 'Jane', buyerAddress: '2 Oak',
+    formSerial: 'F900', eligibilityNote: 'binder A'
+  }, '2026-07-25T00:00:00Z');
+  return log;
+}
+
+test('appendEvent chains seq and prevHash', () => {
+  const log = buildLog();
+  assert.deepEqual(log.map((e) => e.seq), [1, 2, 3]);
+  assert.equal(log[0].prevHash, I.GENESIS);
+  assert.equal(log[1].prevHash, log[0].hash);
+  assert.equal(log[2].prevHash, log[1].hash);
+});
+
+test('verifyChain accepts an untouched log', () => {
+  assert.deepEqual(I.verifyChain(buildLog()), { ok: true, count: 3 });
+});
+
+test('verifyChain detects altered content (tamper)', () => {
+  const log = buildLog();
+  log[0].payload.serial = 'HACKED'; // edit a recorded value in place
+  const res = I.verifyChain(log);
+  assert.equal(res.ok, false);
+  assert.equal(res.brokenAt, 1);
+  assert.match(res.reason, /Altered content/);
+});
+
+test('verifyChain detects a deleted entry (gap/broken link)', () => {
+  const log = buildLog();
+  log.splice(1, 1); // remove the middle event
+  const res = I.verifyChain(log);
+  assert.equal(res.ok, false);
+  // now position 2 holds seq 3 -> sequence gap
+  assert.equal(res.brokenAt, 2);
+});
+
+test('verifyChain detects reorder', () => {
+  const log = buildLog();
+  const tmp = log[0]; log[0] = log[1]; log[1] = tmp;
+  const res = I.verifyChain(log);
+  assert.equal(res.ok, false);
+});
+
+test('project folds events into ledger entries', () => {
+  const entries = I.project(buildLog());
+  assert.equal(entries.length, 2);
+  assert.equal(entries[0].id, 'e1');
+  assert.equal(entries[0].status, 'disposed');
+  assert.equal(entries[0].disposition.buyerName, 'Jane');
+  assert.equal(entries[1].id, 'e2');
+  assert.equal(entries[1].status, 'open');
+});
+
+test('makeBackup + parseBackup round-trips a valid log', () => {
+  const log = buildLog();
+  const text = JSON.stringify(I.makeBackup(log, '2026-07-27T00:00:00Z'));
+  const res = I.parseBackup(text);
+  assert.equal(res.ok, true);
+  assert.equal(res.log.length, 3);
+  assert.deepEqual(I.verifyChain(res.log), { ok: true, count: 3 });
+});
+
+test('parseBackup rejects a tampered backup', () => {
+  const log = buildLog();
+  log[0].payload.serial = 'TAMPERED';
+  const text = JSON.stringify(I.makeBackup(log, '2026-07-27T00:00:00Z'));
+  const res = I.parseBackup(text);
+  assert.equal(res.ok, false);
+  assert.match(res.error, /integrity check/i);
+});
+
+test('parseBackup rejects non-backup and malformed JSON', () => {
+  assert.equal(I.parseBackup('not json').ok, false);
+  assert.equal(I.parseBackup(JSON.stringify({ app: 'something-else', log: [] })).ok, false);
+  assert.equal(I.parseBackup(JSON.stringify({ app: 'bound-book' })).ok, false);
+});
+
+test('parseBackup accepts an empty but valid backup', () => {
+  const text = JSON.stringify(I.makeBackup([], '2026-07-27T00:00:00Z'));
+  const res = I.parseBackup(text);
+  assert.equal(res.ok, true);
+  assert.equal(res.log.length, 0);
+});
+
+test('project applies corrections from the log', () => {
+  let log = buildLog();
+  log = I.appendEvent(log, 'correct', {
+    entryId: 'e1', field: 'acquisition.serial', newValue: 'SN999', reason: 'typo'
+  }, '2026-07-26T00:00:00Z');
+  const entries = I.project(log);
+  const e1 = entries.find((e) => e.id === 'e1');
+  assert.equal(e1.corrections.length, 1);
+  assert.equal(e1.corrections[0].oldValue, 'SN123');
+  assert.equal(e1.corrections[0].newValue, 'SN999');
+  // and the chain is still valid after the correction
+  assert.equal(I.verifyChain(log).ok, true);
+});

--- a/apps/bound-book/integrity.test.js
+++ b/apps/bound-book/integrity.test.js
@@ -142,6 +142,26 @@ test('backupStatus: new events after a backup become pending', () => {
   assert.equal(s.neverBackedUp, false);
 });
 
+test('backupOverdue: no marker or no interval is never overdue', () => {
+  assert.deepEqual(I.backupOverdue(null, '2026-07-27T00:00:00Z', 30), { overdue: false, ageDays: null });
+  assert.deepEqual(I.backupOverdue({ seq: 1, at: '2026-07-01T00:00:00Z' }, '2026-07-27T00:00:00Z', 0), { overdue: false, ageDays: null });
+});
+
+test('backupOverdue: within interval is not overdue', () => {
+  const r = I.backupOverdue({ seq: 1, at: '2026-07-20T00:00:00Z' }, '2026-07-27T00:00:00Z', 30);
+  assert.equal(r.overdue, false);
+  assert.equal(r.ageDays, 7);
+});
+
+test('backupOverdue: at/after interval is overdue', () => {
+  const exactly = I.backupOverdue({ seq: 1, at: '2026-06-27T00:00:00Z' }, '2026-07-27T00:00:00Z', 30);
+  assert.equal(exactly.overdue, true);
+  assert.equal(exactly.ageDays, 30);
+  const past = I.backupOverdue({ seq: 1, at: '2026-05-01T00:00:00Z' }, '2026-07-27T00:00:00Z', 30);
+  assert.equal(past.overdue, true);
+  assert.ok(past.ageDays > 30);
+});
+
 test('project applies corrections from the log', () => {
   let log = buildLog();
   log = I.appendEvent(log, 'correct', {

--- a/apps/bound-book/integrity.test.js
+++ b/apps/bound-book/integrity.test.js
@@ -108,6 +108,40 @@ test('parseBackup accepts an empty but valid backup', () => {
   assert.equal(res.log.length, 0);
 });
 
+test('backupStatus: empty log is up to date', () => {
+  const s = I.backupStatus([], null);
+  assert.equal(s.upToDate, true);
+  assert.equal(s.pending, 0);
+  assert.equal(s.neverBackedUp, false);
+});
+
+test('backupStatus: never backed up flags all events pending', () => {
+  const log = buildLog(); // 3 events
+  const s = I.backupStatus(log, null);
+  assert.equal(s.upToDate, false);
+  assert.equal(s.pending, 3);
+  assert.equal(s.neverBackedUp, true);
+});
+
+test('backupStatus: up to date right after a backup', () => {
+  const log = buildLog();
+  const marker = { seq: I.headSeq(log), at: '2026-07-27T00:00:00Z' };
+  const s = I.backupStatus(log, marker);
+  assert.equal(s.upToDate, true);
+  assert.equal(s.pending, 0);
+  assert.equal(s.lastBackupAt, '2026-07-27T00:00:00Z');
+});
+
+test('backupStatus: new events after a backup become pending', () => {
+  let log = buildLog();
+  const marker = { seq: I.headSeq(log), at: '2026-07-27T00:00:00Z' };
+  log = I.appendEvent(log, 'correct', { entryId: 'e1', field: 'acquisition.model', newValue: 'M2', reason: 'x' }, '2026-07-27T01:00:00Z');
+  const s = I.backupStatus(log, marker);
+  assert.equal(s.pending, 1);
+  assert.equal(s.upToDate, false);
+  assert.equal(s.neverBackedUp, false);
+});
+
 test('project applies corrections from the log', () => {
   let log = buildLog();
   log = I.appendEvent(log, 'correct', {

--- a/apps/bound-book/packages.js
+++ b/apps/bound-book/packages.js
@@ -1,0 +1,346 @@
+// packages.js — inbound package tracking. Pure, storage-agnostic logic for the
+// package registry: carrier detection, status normalization, staleness checks,
+// and reconciliation against the A&D ledger.
+//
+// Deliberately NOT part of the hash-chained event log (integrity.js): package
+// data is third-party logistics information, not a regulated A&D field, and it
+// does not belong in the legal system of record. The only bridge into that
+// record is an ordinary `acquire` event, prefilled from a package — see
+// needsLogging() and linkToEntry().
+//
+// Same conventions as core.js: no Date/random inside pure functions — callers
+// pass ids and timestamps so behavior is deterministic and testable.
+// Runs in the browser (window.Packages) and Node (require) for tests.
+
+(function (root, factory) {
+  if (typeof module === 'object' && module.exports) module.exports = factory();
+  else root.Packages = factory();
+})(typeof self !== 'undefined' ? self : this, function () {
+  'use strict';
+
+  var CARRIERS = [
+    { key: 'usps', label: 'USPS' },
+    { key: 'ups', label: 'UPS' },
+    { key: 'fedex', label: 'FedEx' }
+  ];
+
+  // Normalized status vocabulary. Carrier codes map onto these so the UI and
+  // the staleness checks never care which carrier a package came from.
+  var STATUS = {
+    EXPECTED: 'expected',
+    IN_TRANSIT: 'in_transit',
+    OUT_FOR_DELIVERY: 'out_for_delivery',
+    DELIVERED: 'delivered',
+    EXCEPTION: 'exception',
+    RETURNED: 'returned',
+    UNKNOWN: 'unknown'
+  };
+
+  var STATUS_LABELS = {
+    expected: 'Expected',
+    in_transit: 'In transit',
+    out_for_delivery: 'Out for delivery',
+    delivered: 'Delivered',
+    exception: 'Exception',
+    returned: 'Returned',
+    unknown: 'Unknown'
+  };
+
+  function isKnownCarrier(key) {
+    return CARRIERS.some(function (c) { return c.key === key; });
+  }
+
+  function carrierLabel(key) {
+    for (var i = 0; i < CARRIERS.length; i++) {
+      if (CARRIERS[i].key === key) return CARRIERS[i].label;
+    }
+    return key || 'Unknown carrier';
+  }
+
+  function normalizeTracking(tn) {
+    return String(tn == null ? '' : tn).replace(/\s+/g, '').toUpperCase();
+  }
+
+  // Heuristic carrier detection from the number's shape. The user can always
+  // override it on the form — this only saves typing.
+  function detectCarrier(tn) {
+    var s = normalizeTracking(tn);
+    if (!s) return '';
+    if (/^1Z[0-9A-Z]{16}$/.test(s)) return 'ups';
+    if (/^[A-Z]{2}\d{9}US$/.test(s)) return 'usps';
+    if (/^(92|93|94|95)\d{18,20}$/.test(s)) return 'usps';
+    if (/^61\d{18}$/.test(s)) return 'fedex';
+    if (/^\d{12}$|^\d{15}$/.test(s)) return 'fedex';
+    if (/^\d{20,22}$/.test(s)) return 'usps';
+    return '';
+  }
+
+  // Carrier status codes. UPS uses single letters on status.type; FedEx uses
+  // two-letter derivedCode. USPS v3 returns prose, handled by fromText().
+  var CODE_MAP = {
+    ups: { D: STATUS.DELIVERED, I: STATUS.IN_TRANSIT, P: STATUS.IN_TRANSIT,
+           M: STATUS.EXPECTED, X: STATUS.EXCEPTION, RS: STATUS.RETURNED },
+    fedex: { DL: STATUS.DELIVERED, OD: STATUS.OUT_FOR_DELIVERY, IT: STATUS.IN_TRANSIT,
+             PU: STATUS.IN_TRANSIT, AR: STATUS.IN_TRANSIT, IN: STATUS.EXPECTED,
+             OC: STATUS.EXPECTED, DE: STATUS.EXCEPTION, SE: STATUS.EXCEPTION,
+             CA: STATUS.EXCEPTION, RS: STATUS.RETURNED }
+  };
+
+  function fromText(text) {
+    var t = String(text == null ? '' : text).toLowerCase();
+    if (!t) return null;
+    if (t.indexOf('out for delivery') !== -1) return STATUS.OUT_FOR_DELIVERY;
+    if (t.indexOf('delivered') !== -1) return STATUS.DELIVERED;
+    if (t.indexOf('return') !== -1) return STATUS.RETURNED;
+    if (/alert|exception|undeliverable|held|delay|attempt/.test(t)) return STATUS.EXCEPTION;
+    if (/in transit|arrived|departed|accepted|picked up|in possession|on its way/.test(t)) return STATUS.IN_TRANSIT;
+    if (/label|pre-shipment|order processed|billing information|shipment information/.test(t)) return STATUS.EXPECTED;
+    return null;
+  }
+
+  // Prefer prose for the two states a decision hangs on (a UPS 'I' cannot tell
+  // "out for delivery" from "in transit"), then the code, then prose again.
+  function normalizeStatus(carrier, code, text) {
+    var byText = fromText(text);
+    if (byText === STATUS.OUT_FOR_DELIVERY || byText === STATUS.DELIVERED) return byText;
+    var map = CODE_MAP[carrier];
+    var byCode = (map && code) ? map[String(code).toUpperCase()] : null;
+    if (byCode) return byCode;
+    return byText || STATUS.UNKNOWN;
+  }
+
+  function isBlank(v) {
+    return v === undefined || v === null || String(v).trim() === '';
+  }
+
+  function validatePackage(p) {
+    p = p || {};
+    var errors = [];
+    if (isBlank(p.description)) {
+      errors.push('Describe what you are expecting — a row with no description is not actionable.');
+    }
+    if (!isBlank(p.carrier) && !isKnownCarrier(p.carrier)) {
+      errors.push('Carrier must be USPS, UPS, or FedEx.');
+    }
+    return { ok: errors.length === 0, errors: errors };
+  }
+
+  // Build a new registry row. Caller supplies id and timestamp.
+  function newPackage(input, id, at) {
+    var tn = normalizeTracking(input.trackingNumber);
+    return {
+      id: id,
+      trackingNumber: tn,
+      carrier: input.carrier || detectCarrier(tn),
+      description: input.description || '',
+      expectedBy: input.expectedBy || '',
+      source: input.source || 'manual',
+      status: input.status || STATUS.EXPECTED,
+      lastScan: null,
+      history: [],
+      linkedEntryId: null,
+      addedAt: at,
+      updatedAt: at
+    };
+  }
+
+  // --- poller snapshot merge ---
+
+  function scanKey(s) {
+    return String(s.at || '') + '|' + String(s.description || '');
+  }
+
+  function mergeScans(history, scans) {
+    var seen = {};
+    var out = history.slice();
+    out.forEach(function (s) { seen[scanKey(s)] = true; });
+    scans.forEach(function (s) {
+      if (!seen[scanKey(s)]) { seen[scanKey(s)] = true; out.push(s); }
+    });
+    out.sort(function (a, b) { return String(a.at).localeCompare(String(b.at)); });
+    return out;
+  }
+
+  // Fold a poller snapshot into the registry. Rows already present are updated
+  // (new scans appended, status refreshed); tracking numbers the registry has
+  // never seen are ADDED — that is how portal discovery surfaces a package the
+  // user never registered and no email ever mentioned.
+  function mergeSnapshot(packages, snapshot, now, makeId) {
+    var out = packages.map(clone);
+    var idx = {};
+    out.forEach(function (p, i) { if (p.trackingNumber) idx[p.trackingNumber] = i; });
+
+    var added = 0, updated = 0;
+    var rows = (snapshot && snapshot.packages) || [];
+    rows.forEach(function (r) {
+      var tn = normalizeTracking(r.trackingNumber);
+      if (!tn) return;
+      var scans = (r.scans || []).slice();
+      var last = scans.length ? scans[scans.length - 1] : null;
+      var status = r.status ||
+        (last ? normalizeStatus(r.carrier, last.code, last.description) : STATUS.UNKNOWN);
+      var found = r.discovered || {};
+
+      if (idx[tn] === undefined) {
+        var p = newPackage({
+          trackingNumber: tn,
+          carrier: r.carrier || detectCarrier(tn),
+          description: found.description || ('Found on the ' + carrierLabel(r.carrier || detectCarrier(tn)) + ' portal'),
+          expectedBy: found.expectedBy || '',
+          source: r.source || 'portal'
+        }, makeId(), now);
+        p.history = mergeScans([], scans);
+        p.lastScan = last;
+        if (status !== STATUS.UNKNOWN) p.status = status;
+        out.push(p);
+        idx[tn] = out.length - 1;
+        added++;
+        return;
+      }
+
+      var cur = out[idx[tn]];
+      var before = cur.status + '|' + cur.history.length;
+      cur.history = mergeScans(cur.history, scans);
+      if (cur.history.length) cur.lastScan = cur.history[cur.history.length - 1];
+      if (status !== STATUS.UNKNOWN) cur.status = status;
+      if (!cur.carrier && r.carrier) cur.carrier = r.carrier;
+      if (before !== cur.status + '|' + cur.history.length) {
+        cur.updatedAt = now;
+        updated++;
+      }
+    });
+    return { packages: out, added: added, updated: updated };
+  }
+
+  // The list handed to the poller: every number worth asking a carrier about.
+  // Delivered and returned packages are finished, so they are left out.
+  function trackingList(packages) {
+    return packages
+      .filter(function (p) { return p.trackingNumber && isActive(p); })
+      .map(function (p) { return { trackingNumber: p.trackingNumber, carrier: p.carrier }; });
+  }
+
+  // --- staleness and reconciliation ---
+
+  var DAY_MS = 86400000;
+  var DEFAULT_STALL_DAYS = 4;
+
+  function daysBetween(fromIso, toIso) {
+    var a = new Date(fromIso).getTime();
+    var b = new Date(toIso).getTime();
+    if (isNaN(a) || isNaN(b)) return 0;
+    return Math.floor((b - a) / DAY_MS);
+  }
+
+  // Weekdays elapsed, for the "log it by close of the next business day"
+  // reminder. Holidays are not modeled — this is a nudge, not a legal clock.
+  function businessDaysBetween(fromIso, toIso) {
+    var a = new Date(fromIso).getTime();
+    var b = new Date(toIso).getTime();
+    if (isNaN(a) || isNaN(b) || b <= a) return 0;
+    var d = new Date(a); d.setUTCHours(0, 0, 0, 0);
+    var end = new Date(b); end.setUTCHours(0, 0, 0, 0);
+    var n = 0;
+    while (d.getTime() < end.getTime()) {
+      d = new Date(d.getTime() + DAY_MS);
+      var wd = d.getUTCDay();
+      if (wd !== 0 && wd !== 6) n++;
+    }
+    return n;
+  }
+
+  function isActive(p) {
+    return p.status !== STATUS.DELIVERED && p.status !== STATUS.RETURNED;
+  }
+
+  // Moving, then nothing. This is the case an email-based tracker structurally
+  // cannot see: no email arrives to tell you a package went quiet.
+  function isStalled(p, now, stallDays) {
+    if (!isActive(p)) return false;
+    if (p.status !== STATUS.IN_TRANSIT && p.status !== STATUS.OUT_FOR_DELIVERY) return false;
+    var at = p.lastScan && p.lastScan.at;
+    if (!at) return false;
+    return daysBetween(at, now) >= (stallDays || DEFAULT_STALL_DAYS);
+  }
+
+  // Past the date you said you expected it, and still not here.
+  function isOverdue(p, now) {
+    if (!isActive(p)) return false;
+    if (!p.expectedBy) return false;
+    return daysBetween(p.expectedBy, now) > 0;
+  }
+
+  // Delivered, but never written into the A&D record. For a licensee this is
+  // the one that matters: a received firearm has to reach the bound book.
+  function needsLogging(p) {
+    return p.status === STATUS.DELIVERED && !p.linkedEntryId;
+  }
+
+  function loggingOverdue(p, now, graceBusinessDays) {
+    if (!needsLogging(p)) return false;
+    var at = (p.lastScan && p.lastScan.at) || p.updatedAt;
+    if (!at) return false;
+    var grace = graceBusinessDays === undefined ? 1 : graceBusinessDays;
+    return businessDaysBetween(at, now) > grace;
+  }
+
+  // Everything the Packages screen needs to tell you what to do next.
+  // `entries` is the projected A&D ledger, used to catch links pointing at
+  // entries that no longer exist (e.g. after restoring an older backup).
+  function reconcile(packages, entries, now, opts) {
+    opts = opts || {};
+    var known = {};
+    (entries || []).forEach(function (e) { known[e.id] = true; });
+
+    var out = { active: [], delivered: [], stalled: [], overdue: [], toLog: [], lateToLog: [], orphanLinks: [] };
+    packages.forEach(function (p) {
+      if (p.linkedEntryId && !known[p.linkedEntryId]) out.orphanLinks.push(p);
+      if (isActive(p)) out.active.push(p);
+      else if (p.status === STATUS.DELIVERED) out.delivered.push(p);
+      if (isStalled(p, now, opts.stallDays)) out.stalled.push(p);
+      if (isOverdue(p, now)) out.overdue.push(p);
+      if (needsLogging(p)) {
+        out.toLog.push(p);
+        if (loggingOverdue(p, now, opts.graceBusinessDays)) out.lateToLog.push(p);
+      }
+    });
+    return out;
+  }
+
+  // Tie a delivered package to the A&D entry it became.
+  function linkToEntry(p, entryId, at) {
+    var next = clone(p);
+    next.linkedEntryId = entryId;
+    next.updatedAt = at;
+    return next;
+  }
+
+  function clone(o) {
+    return JSON.parse(JSON.stringify(o));
+  }
+
+  return {
+    CARRIERS: CARRIERS,
+    STATUS: STATUS,
+    STATUS_LABELS: STATUS_LABELS,
+    DEFAULT_STALL_DAYS: DEFAULT_STALL_DAYS,
+    isKnownCarrier: isKnownCarrier,
+    carrierLabel: carrierLabel,
+    normalizeTracking: normalizeTracking,
+    detectCarrier: detectCarrier,
+    normalizeStatus: normalizeStatus,
+    validatePackage: validatePackage,
+    newPackage: newPackage,
+    mergeSnapshot: mergeSnapshot,
+    trackingList: trackingList,
+    daysBetween: daysBetween,
+    businessDaysBetween: businessDaysBetween,
+    isActive: isActive,
+    isStalled: isStalled,
+    isOverdue: isOverdue,
+    needsLogging: needsLogging,
+    loggingOverdue: loggingOverdue,
+    reconcile: reconcile,
+    linkToEntry: linkToEntry
+  };
+});

--- a/apps/bound-book/packages.test.js
+++ b/apps/bound-book/packages.test.js
@@ -1,0 +1,178 @@
+// Run: node --test  (from apps/bound-book/)
+const test = require('node:test');
+const assert = require('node:assert');
+const P = require('./packages.js');
+
+let n = 0;
+const ids = () => 'p' + (++n);
+const NOW = '2026-08-27T12:00:00.000Z';
+
+function pkg(over = {}) {
+  const p = P.newPackage(
+    Object.assign({ description: 'Glock 19 from Acme', trackingNumber: '1Z999AA10123456784' }, over),
+    'p0',
+    '2026-08-01T00:00:00.000Z'
+  );
+  return Object.assign(p, over.__patch || {});
+}
+
+test('detectCarrier recognizes each carrier format', () => {
+  assert.equal(P.detectCarrier('1Z999AA10123456784'), 'ups');
+  assert.equal(P.detectCarrier('9400 1000 0000 0000 0000 00'), 'usps');
+  assert.equal(P.detectCarrier('LN123456789US'), 'usps');
+  assert.equal(P.detectCarrier('123456789012'), 'fedex');
+  assert.equal(P.detectCarrier('612345678901234567 89'), 'fedex');
+  assert.equal(P.detectCarrier('nonsense'), '');
+});
+
+test('normalizeStatus prefers prose over code for out-for-delivery', () => {
+  // UPS reports 'I' (in transit) even on the delivery truck; the prose is the
+  // only thing that distinguishes it.
+  assert.equal(P.normalizeStatus('ups', 'I', 'Out For Delivery Today'), P.STATUS.OUT_FOR_DELIVERY);
+  assert.equal(P.normalizeStatus('ups', 'I', 'Arrived at Facility'), P.STATUS.IN_TRANSIT);
+  assert.equal(P.normalizeStatus('ups', 'D', ''), P.STATUS.DELIVERED);
+  assert.equal(P.normalizeStatus('fedex', 'OD', ''), P.STATUS.OUT_FOR_DELIVERY);
+  assert.equal(P.normalizeStatus('fedex', 'DE', ''), P.STATUS.EXCEPTION);
+  assert.equal(P.normalizeStatus('usps', '', 'Delivered, In/At Mailbox'), P.STATUS.DELIVERED);
+  assert.equal(P.normalizeStatus('usps', '', 'Alert: Delivery Delayed'), P.STATUS.EXCEPTION);
+  assert.equal(P.normalizeStatus('usps', '', ''), P.STATUS.UNKNOWN);
+});
+
+test('validatePackage requires a description', () => {
+  assert.equal(P.validatePackage({ description: '' }).ok, false);
+  assert.equal(P.validatePackage({ description: 'Ammo' }).ok, true);
+});
+
+test('newPackage infers the carrier and normalizes the tracking number', () => {
+  const p = P.newPackage({ description: 'x', trackingNumber: ' 1z999aa1 0123456784 ' }, 'p1', NOW);
+  assert.equal(p.trackingNumber, '1Z999AA10123456784');
+  assert.equal(p.carrier, 'ups');
+  assert.equal(p.status, P.STATUS.EXPECTED);
+  assert.equal(p.linkedEntryId, null);
+});
+
+test('mergeSnapshot updates a known package and appends new scans', () => {
+  const existing = [pkg()];
+  const snap = {
+    packages: [{
+      trackingNumber: '1Z999AA10123456784',
+      carrier: 'ups',
+      scans: [
+        { at: '2026-08-02T10:00:00Z', description: 'Origin Scan' },
+        { at: '2026-08-03T10:00:00Z', description: 'Out For Delivery Today', code: 'I' }
+      ]
+    }]
+  };
+  const res = P.mergeSnapshot(existing, snap, NOW, ids);
+  assert.equal(res.added, 0);
+  assert.equal(res.updated, 1);
+  assert.equal(res.packages[0].status, P.STATUS.OUT_FOR_DELIVERY);
+  assert.equal(res.packages[0].history.length, 2);
+  assert.equal(res.packages[0].lastScan.description, 'Out For Delivery Today');
+});
+
+test('mergeSnapshot is idempotent — re-importing the same snapshot adds nothing', () => {
+  const snap = {
+    packages: [{
+      trackingNumber: '1Z999AA10123456784', carrier: 'ups',
+      scans: [{ at: '2026-08-02T10:00:00Z', description: 'Origin Scan' }]
+    }]
+  };
+  const once = P.mergeSnapshot([pkg()], snap, NOW, ids);
+  const twice = P.mergeSnapshot(once.packages, snap, NOW, ids);
+  assert.equal(twice.added, 0);
+  assert.equal(twice.updated, 0);
+  assert.equal(twice.packages[0].history.length, 1);
+});
+
+test('mergeSnapshot ADDS a package the registry never knew about (portal discovery)', () => {
+  const snap = {
+    packages: [{
+      trackingNumber: '9400111899223197428490', carrier: 'usps', source: 'portal',
+      discovered: { description: 'Package from Brownells' },
+      scans: [{ at: '2026-08-26T09:00:00Z', description: 'In Transit to Next Facility' }]
+    }]
+  };
+  const res = P.mergeSnapshot([], snap, NOW, ids);
+  assert.equal(res.added, 1);
+  assert.equal(res.packages[0].source, 'portal');
+  assert.equal(res.packages[0].description, 'Package from Brownells');
+  assert.equal(res.packages[0].status, P.STATUS.IN_TRANSIT);
+});
+
+test('mergeSnapshot ignores rows with no tracking number', () => {
+  const res = P.mergeSnapshot([], { packages: [{ trackingNumber: '' }] }, NOW, ids);
+  assert.equal(res.added, 0);
+  assert.equal(res.packages.length, 0);
+});
+
+test('trackingList covers only active, numbered packages', () => {
+  const delivered = pkg({ __patch: { status: P.STATUS.DELIVERED } });
+  const noNumber = P.newPackage({ description: 'Expected, no number yet' }, 'p2', NOW);
+  const active = P.newPackage({ description: 'a', trackingNumber: '123456789012' }, 'p3', NOW);
+  const list = P.trackingList([delivered, noNumber, active]);
+  assert.deepEqual(list, [{ trackingNumber: '123456789012', carrier: 'fedex' }]);
+});
+
+test('isStalled catches a package that went quiet mid-transit', () => {
+  const moving = pkg({ __patch: {
+    status: P.STATUS.IN_TRANSIT,
+    lastScan: { at: '2026-08-20T10:00:00Z', description: 'Departed Facility' }
+  } });
+  assert.equal(P.isStalled(moving, NOW), true);          // 7 days, default threshold 4
+  assert.equal(P.isStalled(moving, '2026-08-22T10:00:00Z'), false); // 2 days
+  const delivered = pkg({ __patch: {
+    status: P.STATUS.DELIVERED,
+    lastScan: { at: '2026-08-20T10:00:00Z', description: 'Delivered' }
+  } });
+  assert.equal(P.isStalled(delivered, NOW), false);
+});
+
+test('isOverdue fires past expectedBy, and never once it has arrived', () => {
+  assert.equal(P.isOverdue(pkg({ expectedBy: '2026-08-20' }), NOW), true);
+  assert.equal(P.isOverdue(pkg({ expectedBy: '2026-09-30' }), NOW), false);
+  assert.equal(P.isOverdue(pkg({ __patch: { status: P.STATUS.DELIVERED }, expectedBy: '2026-08-20' }), NOW), false);
+});
+
+test('businessDaysBetween skips weekends', () => {
+  // Fri 2026-08-21 -> Mon 2026-08-24 is one business day.
+  assert.equal(P.businessDaysBetween('2026-08-21T10:00:00Z', '2026-08-24T10:00:00Z'), 1);
+  assert.equal(P.businessDaysBetween('2026-08-24T10:00:00Z', '2026-08-27T10:00:00Z'), 3);
+  assert.equal(P.businessDaysBetween('2026-08-27T10:00:00Z', '2026-08-24T10:00:00Z'), 0);
+});
+
+test('needsLogging / loggingOverdue track the handoff into the A&D record', () => {
+  const justDelivered = pkg({ __patch: {
+    status: P.STATUS.DELIVERED,
+    lastScan: { at: '2026-08-26T10:00:00Z', description: 'Delivered' }
+  } });
+  assert.equal(P.needsLogging(justDelivered), true);
+  assert.equal(P.loggingOverdue(justDelivered, NOW), false);   // 1 business day, within grace
+
+  const sittingThere = pkg({ __patch: {
+    status: P.STATUS.DELIVERED,
+    lastScan: { at: '2026-08-20T10:00:00Z', description: 'Delivered' }
+  } });
+  assert.equal(P.loggingOverdue(sittingThere, NOW), true);
+
+  const logged = P.linkToEntry(sittingThere, 'entry-1', NOW);
+  assert.equal(P.needsLogging(logged), false);
+  assert.equal(P.loggingOverdue(logged, NOW), false);
+  assert.equal(sittingThere.linkedEntryId, null, 'linkToEntry must not mutate its input');
+});
+
+test('reconcile buckets everything the Packages screen needs', () => {
+  const packages = [
+    pkg({ __patch: { id: 'a', status: P.STATUS.IN_TRANSIT, lastScan: { at: '2026-08-20T10:00:00Z', description: 'Departed' } } }),
+    pkg({ __patch: { id: 'b', status: P.STATUS.DELIVERED, lastScan: { at: '2026-08-20T10:00:00Z', description: 'Delivered' } } }),
+    pkg({ __patch: { id: 'c', status: P.STATUS.DELIVERED, linkedEntryId: 'gone' } }),
+    P.newPackage({ description: 'late', trackingNumber: '123456789012', expectedBy: '2026-08-01' }, 'd', NOW)
+  ];
+  const rec = P.reconcile(packages, [{ id: 'entry-1' }], NOW);
+  assert.deepEqual(rec.stalled.map(p => p.id), ['a']);
+  assert.deepEqual(rec.toLog.map(p => p.id), ['b']);
+  assert.deepEqual(rec.lateToLog.map(p => p.id), ['b']);
+  assert.deepEqual(rec.orphanLinks.map(p => p.id), ['c']);
+  assert.deepEqual(rec.overdue.map(p => p.id), ['d']);
+  assert.deepEqual(rec.active.map(p => p.id), ['a', 'd']);
+});

--- a/apps/bound-book/styles.css
+++ b/apps/bound-book/styles.css
@@ -1,0 +1,152 @@
+:root {
+  --ink: #1a1a1a;
+  --muted: #666;
+  --line: #d8d8d8;
+  --bg: #f6f6f4;
+  --accent: #2b5c3f;
+  --err: #b00020;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font: 15px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  color: var(--ink);
+  background: var(--bg);
+}
+
+.hidden { display: none !important; }
+
+.topbar {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.6rem 1rem;
+  background: #fff;
+  border-bottom: 1px solid var(--line);
+  flex-wrap: wrap;
+}
+.brand { font-weight: 700; }
+.tag {
+  font-size: 0.7rem;
+  background: var(--accent);
+  color: #fff;
+  padding: 0.1rem 0.4rem;
+  border-radius: 4px;
+  vertical-align: middle;
+}
+nav { display: flex; gap: 0.25rem; flex-wrap: wrap; }
+nav button {
+  border: 1px solid transparent;
+  background: none;
+  padding: 0.4rem 0.7rem;
+  border-radius: 6px;
+  cursor: pointer;
+  font: inherit;
+}
+nav button:hover { background: var(--bg); }
+nav button.active { background: var(--accent); color: #fff; }
+
+main { max-width: 900px; margin: 1.2rem auto; padding: 0 1rem; }
+h1 { font-size: 1.4rem; margin: 0 0 0.3rem; }
+.hint { color: var(--muted); margin: 0 0 1rem; }
+
+.grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.8rem;
+  background: #fff;
+  padding: 1.2rem;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+}
+.grid label { display: flex; flex-direction: column; gap: 0.25rem; font-size: 0.85rem; color: var(--muted); }
+.grid input, .grid select {
+  font: inherit;
+  color: var(--ink);
+  padding: 0.45rem 0.5rem;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+}
+.span2 { grid-column: 1 / -1; }
+fieldset.span2 {
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 0.6rem;
+}
+fieldset legend { color: var(--ink); font-weight: 600; padding: 0 0.4rem; }
+
+button[type="submit"], .actions button, #disclaimer-ok {
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  padding: 0.6rem 1rem;
+  border-radius: 6px;
+  font: inherit;
+  cursor: pointer;
+}
+button[type="submit"]:hover, .actions button:hover { filter: brightness(1.08); }
+#disclaimer-ok:disabled { opacity: 0.5; cursor: not-allowed; }
+
+.pick { display: block; margin-bottom: 0.8rem; }
+.pick select { font: inherit; padding: 0.45rem; border: 1px solid var(--line); border-radius: 6px; margin-left: 0.5rem; }
+
+.errors { color: var(--err); font-size: 0.85rem; }
+.errors ul { margin: 0; padding-left: 1.2rem; }
+.saved { color: var(--accent); font-size: 0.85rem; }
+
+#ledger-search { width: 100%; padding: 0.5rem; border: 1px solid var(--line); border-radius: 6px; margin-bottom: 0.8rem; }
+
+table { width: 100%; border-collapse: collapse; background: #fff; }
+th, td { text-align: left; padding: 0.5rem 0.6rem; border-bottom: 1px solid var(--line); font-size: 0.85rem; vertical-align: top; }
+th { background: #efefec; }
+.status-open { color: var(--accent); font-weight: 600; }
+.status-disposed { color: var(--muted); }
+.struck { text-decoration: line-through; color: var(--muted); }
+.corr { display: block; font-size: 0.75rem; color: var(--accent); }
+.empty { color: var(--muted); padding: 1rem 0; }
+
+.actions { display: flex; gap: 0.6rem; margin-bottom: 1rem; }
+.link-btn { background: none; border: none; color: var(--accent); cursor: pointer; font: inherit; text-decoration: underline; padding: 0; }
+#correct-cancel { background: none; color: var(--muted); border: 1px solid var(--line); }
+
+.chain-ok { background: #e7f3ec; color: var(--accent); border: 1px solid #bfe0cc; padding: 0.7rem 0.9rem; border-radius: 6px; font-weight: 600; }
+.chain-bad { background: #fbe9ec; color: var(--err); border: 1px solid #f0c2ca; padding: 0.7rem 0.9rem; border-radius: 6px; font-weight: 600; }
+#integrity-log { margin-top: 1rem; }
+.mono { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 0.8rem; color: var(--muted); }
+tr.row-bad td { background: #fbe9ec; }
+.restore-btn { background: none; color: var(--accent); border: 1px solid var(--accent); padding: 0.6rem 1rem; border-radius: 6px; cursor: pointer; }
+#restore-msg { margin-top: 0.7rem; }
+#restore-msg:empty { margin-top: 0; }
+
+.modal {
+  position: fixed; inset: 0;
+  background: rgba(0,0,0,0.45);
+  display: flex; align-items: center; justify-content: center;
+  padding: 1rem; z-index: 10;
+}
+.modal-card {
+  background: #fff; border-radius: 10px; padding: 1.4rem; max-width: 460px;
+}
+.modal-card h2 { margin-top: 0; }
+.check { display: block; margin: 0.8rem 0; }
+
+/* Print: only the export ledger shows, formatted as a bound book. */
+@media print {
+  .no-print, .topbar, nav { display: none !important; }
+  main { max-width: none; margin: 0; }
+  .view:not(#view-export) { display: none !important; }
+  #view-export h1, #view-export .hint { display: none; }
+  body { background: #fff; }
+  table { font-size: 11px; }
+  th { background: #eee !important; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+  .ledger-header { margin-bottom: 0.5rem; }
+}
+
+.ledger-header { display: none; }
+@media print { .ledger-header { display: block; } }
+.ledger-header h2 { margin: 0; }
+.ledger-header .meta { font-size: 12px; color: #333; }

--- a/apps/bound-book/styles.css
+++ b/apps/bound-book/styles.css
@@ -118,6 +118,8 @@ th { background: #efefec; }
 #integrity-log { margin-top: 1rem; }
 .mono { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 0.8rem; color: var(--muted); }
 tr.row-bad td { background: #fbe9ec; }
+.backup-ok { margin-top: 0.6rem; color: var(--accent); font-size: 0.9rem; }
+.backup-warn { margin-top: 0.6rem; background: #fdf3e3; color: #8a5a00; border: 1px solid #f0d9a8; padding: 0.6rem 0.8rem; border-radius: 6px; font-weight: 600; }
 .restore-btn { background: none; color: var(--accent); border: 1px solid var(--accent); padding: 0.6rem 1rem; border-radius: 6px; cursor: pointer; }
 #restore-msg { margin-top: 0.7rem; }
 #restore-msg:empty { margin-top: 0; }

--- a/apps/bound-book/styles.css
+++ b/apps/bound-book/styles.css
@@ -152,3 +152,21 @@ tr.row-bad td { background: #fbe9ec; }
 @media print { .ledger-header { display: block; } }
 .ledger-header h2 { margin: 0; }
 .ledger-header .meta { font-size: 12px; color: #333; }
+
+/* --- Packages (working list; not part of the A&D record) --- */
+#packages-alerts:not(:empty) { margin-bottom: 1rem; }
+#packages-alerts > div + div { margin-top: 0.5rem; }
+#snapshot-msg:not(:empty) { margin: 0.7rem 0; }
+#package-add { background: #fff; border: 1px solid var(--line); border-radius: 8px; margin-bottom: 1rem; }
+#package-add summary { padding: 0.7rem 1rem; cursor: pointer; color: var(--accent); font-weight: 600; }
+#package-add[open] summary { border-bottom: 1px solid var(--line); }
+#package-add .grid { border: none; }
+.pkg-banner { background: #e7f3ec; border: 1px solid #bfe0cc; border-radius: 6px; padding: 0.7rem 0.9rem; margin-bottom: 1rem; font-size: 0.9rem; }
+.pkg-status { font-weight: 600; white-space: nowrap; }
+.pkg-delivered { color: var(--accent); }
+.pkg-out_for_delivery { color: #8a5a00; }
+.pkg-exception, .pkg-returned { color: var(--err); }
+.pkg-expected, .pkg-unknown { color: var(--muted); }
+.pkg-note { display: block; font-size: 0.75rem; color: var(--muted); }
+.pkg-flag { display: block; font-size: 0.75rem; color: var(--err); font-weight: 600; }
+tr.row-warn td { background: #fdf3e3; }

--- a/apps/bound-book/tracker/.gitignore
+++ b/apps/bound-book/tracker/.gitignore
@@ -1,0 +1,8 @@
+# Carrier API credentials — never commit.
+config.json
+# Saved portal browser sessions (cookies for your USPS/UPS/FedEx accounts).
+state/
+# Poller output and the tracking list exported from the app.
+package-snapshot.json
+tracking-list.json
+node_modules/

--- a/apps/bound-book/tracker/README.md
+++ b/apps/bound-book/tracker/README.md
@@ -1,0 +1,108 @@
+# Package poller
+
+Fetches the real status of inbound packages and writes a snapshot the Bound
+Book app imports. Runs on your machine, on demand.
+
+## Why there is a separate program at all
+
+The app is a double-click `index.html` with no server. It cannot call carrier
+APIs itself: a `file://` page has no CORS access to them, and an API secret
+pasted into a web page is a published secret. So the network half lives here,
+in Node, and the two halves meet over a file — the same round-trip the app
+already uses for backup/restore.
+
+## What it can and cannot do
+
+**No carrier offers an "everything inbound to my address" API.** This is worth
+being blunt about, because it shapes the whole design:
+
+| | What exists | What that means here |
+|---|---|---|
+| USPS | [Informed Delivery API](https://postalpro.usps.com/idapi) is for *mailers* running campaigns; the tracking API takes a tracking number | No resident feed |
+| UPS | [Track API](https://github.com/UPS-API/api-documentation/blob/main/Tracking.yaml) — `/track/v1/details/{inquiryNumber}` | Number in, status out |
+| FedEx | Track API — `POST /track/v1/trackingnumbers` | Number in, status out |
+
+The consumer dashboards that *do* show everything coming to your address —
+Informed Delivery, UPS My Choice, FedEx Delivery Manager — are web pages with
+no public API. So this tool splits the job:
+
+- **Portals discover tracking numbers.** A headless browser opens your
+  dashboard and reads the tracking numbers off it. That is all it takes from
+  the page.
+- **The official APIs decide status.** Every number, whether you registered it
+  or the portal found it, is resolved against the carrier's real API.
+
+Scraping numbers rather than status is deliberate. A tracking number's shape
+survives a portal redesign; a CSS selector for "delivery status" does not. When
+a carrier ships a new dashboard, this degrades to *"found 0 numbers"* — visible
+and fixable — instead of silently reporting stale status.
+
+## Your passwords are not stored
+
+`login` opens a **real browser window** and you sign in yourself — password,
+MFA, captcha, whatever the carrier asks. Only the resulting session cookies are
+written, to `state/<carrier>.json`. Nothing reads or stores your password.
+
+`state/` and `config.json` are gitignored. `state/` holds live sessions for your
+carrier accounts, so treat that directory like a password manager: it stays on
+this machine.
+
+Sessions expire. When one does, the poller says so and names the fix.
+
+## Setup
+
+**1. Carrier API credentials** (for status). Register a free developer app at
+[developer.usps.com](https://developers.usps.com/), [developer.ups.com](https://developer.ups.com/),
+and [developer.fedex.com](https://developer.fedex.com/), then:
+
+```bash
+cp config.example.json config.json   # paste each clientId / clientSecret
+```
+
+Or keep them out of the file entirely with env vars:
+`BB_USPS_CLIENT_ID`, `BB_USPS_CLIENT_SECRET`, `BB_UPS_…`, `BB_FEDEX_…`.
+
+Credentials are per-carrier and independent — configure one and the other two
+simply report that they are unconfigured.
+
+**2. Portal sessions** (for discovery, optional):
+
+```bash
+npm install playwright && npx playwright install chromium
+node poll.js login usps
+node poll.js login ups
+node poll.js login fedex
+```
+
+Skip this entirely and pass `--no-portals`; you then track only the numbers you
+register in the app.
+
+## Daily use
+
+```bash
+# 1. In the app: Packages → Download tracking list, save it next to poll.js
+# 2. Poll:
+node poll.js poll --list tracking-list.json
+# 3. In the app: Packages → Import snapshot… → package-snapshot.json
+```
+
+Options: `--numbers 1Z…,94…` to add numbers inline, `--no-portals` to skip
+discovery, `--out <file>` to write elsewhere, `--headed` to watch the browser
+work, `--dump` to save the portal's HTML and a screenshot when discovery finds
+nothing and you need to see why.
+
+Nothing here runs on a schedule. If you want it to, wrap it in `cron` — but the
+import step is still manual by design, so the app never has a network listener.
+
+## Layout
+
+| File | Role |
+|------|------|
+| `poll.js` | CLI: `login`, `poll`. Orchestration and snapshot writing. |
+| `carriers.js` | The three official APIs, normalized to one row shape. Authoritative for status. |
+| `portals.js` | Playwright session login + tracking-number discovery. Never sets status. |
+| `carriers.test.js` | Response-shape fixtures for all three carriers. Run `node --test` from `apps/bound-book/`. |
+
+`carriers.test.js` is where a carrier's API change should surface: the fixtures
+are the documented response shapes, so if one drifts, that file fails rather
+than the poller quietly returning nothing.

--- a/apps/bound-book/tracker/carriers.js
+++ b/apps/bound-book/tracker/carriers.js
@@ -1,0 +1,251 @@
+// carriers.js — the three official carrier tracking APIs, normalized to one
+// shape. Each adapter takes tracking numbers and returns rows the browser app
+// can merge (see ../packages.js mergeSnapshot).
+//
+// These are the AUTHORITATIVE source of status. The portal scrapers
+// (portals.js) only discover tracking numbers; they never decide status.
+//
+// Credentials are API client id/secret from each carrier's developer portal —
+// NOT your consumer account password. Nothing here logs into your account.
+
+'use strict';
+
+const OUT_SHAPE = { trackingNumber: '', carrier: '', status: '', scans: [], error: null };
+
+async function fetchJson(url, options, what) {
+  const res = await fetch(url, options);
+  const text = await res.text();
+  let body = null;
+  try { body = text ? JSON.parse(text) : null; } catch (e) { /* non-JSON error page */ }
+  if (!res.ok) {
+    const detail = (body && (body.error_description || body.error || body.message)) || text.slice(0, 200);
+    throw new Error(`${what} failed (HTTP ${res.status}): ${detail}`);
+  }
+  return body;
+}
+
+function row(trackingNumber, carrier, extra) {
+  return Object.assign({}, OUT_SHAPE, { trackingNumber, carrier, scans: [] }, extra);
+}
+
+function chunk(arr, size) {
+  const out = [];
+  for (let i = 0; i < arr.length; i += size) out.push(arr.slice(i, i + size));
+  return out;
+}
+
+// --- USPS (apis.usps.com, OAuth2 client credentials) ---
+
+const usps = {
+  key: 'usps',
+  async token(creds) {
+    const body = await fetchJson('https://apis.usps.com/oauth2/v3/token', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        grant_type: 'client_credentials',
+        client_id: creds.clientId,
+        client_secret: creds.clientSecret
+      })
+    }, 'USPS token');
+    return body.access_token;
+  },
+  async track(numbers, creds) {
+    const token = await this.token(creds);
+    const out = [];
+    // USPS tracking is one number per request.
+    for (const tn of numbers) {
+      try {
+        const body = await fetchJson(
+          `https://apis.usps.com/tracking/v3/tracking/${encodeURIComponent(tn)}?expand=DETAIL`,
+          { headers: { authorization: `Bearer ${token}`, accept: 'application/json' } },
+          `USPS tracking ${tn}`
+        );
+        const events = body.trackingEvents || [];
+        out.push(row(tn, 'usps', {
+          status: '',
+          scans: events.map(e => ({
+            at: e.eventTimestamp || '',
+            code: e.eventCode || '',
+            description: e.eventType || e.eventName || '',
+            location: [e.eventCity, e.eventState].filter(Boolean).join(', ')
+          })).reverse(), // USPS returns newest first; the app wants oldest first
+          summary: body.statusSummary || body.status || ''
+        }));
+      } catch (err) {
+        out.push(row(tn, 'usps', { error: err.message }));
+      }
+    }
+    return out;
+  }
+};
+
+// --- UPS (onlinetools.ups.com, OAuth2 client credentials) ---
+
+const ups = {
+  key: 'ups',
+  async token(creds) {
+    const basic = Buffer.from(`${creds.clientId}:${creds.clientSecret}`).toString('base64');
+    const body = await fetchJson('https://onlinetools.ups.com/security/v1/oauth/token', {
+      method: 'POST',
+      headers: {
+        authorization: `Basic ${basic}`,
+        'content-type': 'application/x-www-form-urlencoded'
+      },
+      body: 'grant_type=client_credentials'
+    }, 'UPS token');
+    return body.access_token;
+  },
+  async track(numbers, creds) {
+    const token = await this.token(creds);
+    const out = [];
+    for (const tn of numbers) {
+      try {
+        const body = await fetchJson(
+          `https://onlinetools.ups.com/api/track/v1/details/${encodeURIComponent(tn)}`,
+          {
+            headers: {
+              authorization: `Bearer ${token}`,
+              transId: `bb-${Date.now()}`,
+              transactionSrc: 'bound-book',
+              accept: 'application/json'
+            }
+          },
+          `UPS tracking ${tn}`
+        );
+        const shipments = (body.trackResponse && body.trackResponse.shipment) || [];
+        const activities = shipments
+          .flatMap(s => s.package || [])
+          .flatMap(p => p.activity || []);
+        out.push(row(tn, 'ups', {
+          scans: activities.map(a => ({
+            at: upsDate(a.date, a.time),
+            code: (a.status && a.status.type) || '',
+            description: (a.status && a.status.description) || '',
+            location: upsPlace(a.location)
+          })).reverse() // UPS returns newest first
+        }));
+      } catch (err) {
+        out.push(row(tn, 'ups', { error: err.message }));
+      }
+    }
+    return out;
+  }
+};
+
+// UPS gives local date/time as YYYYMMDD / HHMMSS with no zone. Keep it as a
+// plain local-time ISO string rather than inventing a UTC offset.
+function upsDate(date, time) {
+  if (!date) return '';
+  const d = `${date.slice(0, 4)}-${date.slice(4, 6)}-${date.slice(6, 8)}`;
+  if (!time) return d;
+  return `${d}T${time.slice(0, 2)}:${time.slice(2, 4)}:${time.slice(4, 6)}`;
+}
+
+function upsPlace(location) {
+  const a = (location && location.address) || {};
+  return [a.city, a.stateProvince, a.countryCode].filter(Boolean).join(', ');
+}
+
+// --- FedEx (apis.fedex.com, OAuth2 client credentials) ---
+
+const fedex = {
+  key: 'fedex',
+  async token(creds) {
+    const body = await fetchJson('https://apis.fedex.com/oauth/token', {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: 'client_credentials',
+        client_id: creds.clientId,
+        client_secret: creds.clientSecret
+      }).toString()
+    }, 'FedEx token');
+    return body.access_token;
+  },
+  async track(numbers, creds) {
+    const token = await this.token(creds);
+    const out = [];
+    // FedEx accepts up to 30 numbers per call.
+    for (const batch of chunk(numbers, 30)) {
+      try {
+        const body = await fetchJson('https://apis.fedex.com/track/v1/trackingnumbers', {
+          method: 'POST',
+          headers: {
+            authorization: `Bearer ${token}`,
+            'content-type': 'application/json',
+            'x-locale': 'en_US'
+          },
+          body: JSON.stringify({
+            includeDetailedScans: true,
+            trackingInfo: batch.map(tn => ({ trackingNumberInfo: { trackingNumber: tn } }))
+          })
+        }, 'FedEx tracking');
+        const results = (body.output && body.output.completeTrackResults) || [];
+        for (const r of results) {
+          const t = (r.trackResults && r.trackResults[0]) || {};
+          if (t.error) {
+            out.push(row(r.trackingNumber, 'fedex', { error: t.error.message || t.error.code }));
+            continue;
+          }
+          const latest = t.latestStatusDetail || {};
+          out.push(row(r.trackingNumber, 'fedex', {
+            scans: (t.scanEvents || []).map(e => ({
+              at: e.date || '',
+              code: e.derivedStatusCode || e.eventType || '',
+              description: e.eventDescription || '',
+              location: fedexPlace(e.scanLocation)
+            })).reverse(), // FedEx returns newest first
+            summary: latest.statusByLocale || latest.description || '',
+            latestCode: latest.derivedCode || ''
+          }));
+        }
+      } catch (err) {
+        for (const tn of batch) out.push(row(tn, 'fedex', { error: err.message }));
+      }
+    }
+    return out;
+  }
+};
+
+function fedexPlace(loc) {
+  const a = loc || {};
+  return [a.city, a.stateOrProvinceCode, a.countryCode].filter(Boolean).join(', ');
+}
+
+const ADAPTERS = { usps, ups, fedex };
+
+// Track a mixed list of { trackingNumber, carrier } against whichever carriers
+// are configured. Numbers whose carrier has no credentials are reported as
+// errors rather than silently dropped — a missing key should be visible.
+async function trackAll(items, config) {
+  const byCarrier = {};
+  for (const it of items) {
+    const c = it.carrier || '';
+    (byCarrier[c] = byCarrier[c] || []).push(it.trackingNumber);
+  }
+  const out = [];
+  for (const [carrier, numbers] of Object.entries(byCarrier)) {
+    const adapter = ADAPTERS[carrier];
+    const creds = config[carrier];
+    if (!adapter) {
+      for (const tn of numbers) out.push(row(tn, carrier, { error: 'Unknown carrier — set it on the package.' }));
+      continue;
+    }
+    if (!creds || !creds.clientId || !creds.clientSecret) {
+      for (const tn of numbers) out.push(row(tn, carrier, { error: `No ${carrier} API credentials in config.json.` }));
+      continue;
+    }
+    try {
+      out.push(...await adapter.track(numbers, creds));
+    } catch (err) {
+      // Token failures throw before any package is attempted. Attribute the
+      // error to every number for this carrier so one carrier's expired
+      // credentials cannot wipe out the other two carriers' results.
+      for (const tn of numbers) out.push(row(tn, carrier, { error: err.message }));
+    }
+  }
+  return out;
+}
+
+module.exports = { trackAll, ADAPTERS };

--- a/apps/bound-book/tracker/carriers.test.js
+++ b/apps/bound-book/tracker/carriers.test.js
@@ -1,0 +1,143 @@
+// Run: node --test  (from apps/bound-book/)
+//
+// These pin down how each carrier's JSON is parsed. There is no way to hit the
+// live APIs from a test, so the fixtures below are the documented response
+// shapes — if a carrier changes theirs, this is the file that should fail.
+const test = require('node:test');
+const assert = require('node:assert');
+const carriers = require('./carriers.js');
+const { statusOf } = require('./poll.js');
+const P = require('../packages.js');
+
+const CREDS = { clientId: 'id', clientSecret: 'secret' };
+const CONFIG = { usps: CREDS, ups: CREDS, fedex: CREDS, portals: {} };
+
+const FIXTURES = {
+  'apis.usps.com/oauth2': { access_token: 't' },
+  'onlinetools.ups.com/security': { access_token: 't' },
+  'apis.fedex.com/oauth': { access_token: 't' },
+
+  'apis.usps.com/tracking': {
+    trackingNumber: '9400111899223197428490',
+    status: 'In Transit to Next Facility',
+    statusSummary: 'In Transit to Next Facility, Arriving Late',
+    trackingEvents: [
+      { eventType: 'In Transit to Next Facility', eventTimestamp: '2026-08-26T09:12:00Z', eventCity: 'DES MOINES', eventState: 'IA', eventCode: 'NT' },
+      { eventType: 'Accepted at USPS Origin Facility', eventTimestamp: '2026-08-24T15:02:00Z', eventCity: 'GRIMES', eventState: 'IA', eventCode: '03' }
+    ]
+  },
+
+  'onlinetools.ups.com/api/track': {
+    trackResponse: {
+      shipment: [{
+        package: [{
+          trackingNumber: '1Z999AA10123456784',
+          activity: [
+            { status: { type: 'D', description: 'Delivered', code: 'KB' }, date: '20260826', time: '142300',
+              location: { address: { city: 'ATLANTA', stateProvince: 'GA', countryCode: 'US' } } },
+            { status: { type: 'I', description: 'Out For Delivery Today', code: 'OT' }, date: '20260826', time: '061200',
+              location: { address: { city: 'ATLANTA', stateProvince: 'GA', countryCode: 'US' } } }
+          ]
+        }]
+      }]
+    }
+  },
+
+  'apis.fedex.com/track': {
+    output: {
+      completeTrackResults: [{
+        trackingNumber: '123456789012',
+        trackResults: [{
+          latestStatusDetail: { code: 'OD', derivedCode: 'OD', statusByLocale: 'On FedEx vehicle for delivery' },
+          scanEvents: [
+            { date: '2026-08-27T06:10:00-05:00', derivedStatusCode: 'OD', eventDescription: 'On FedEx vehicle for delivery',
+              scanLocation: { city: 'MEMPHIS', stateOrProvinceCode: 'TN', countryCode: 'US' } },
+            { date: '2026-08-26T21:00:00-05:00', derivedStatusCode: 'AR', eventDescription: 'Arrived at FedEx location',
+              scanLocation: { city: 'MEMPHIS', stateOrProvinceCode: 'TN', countryCode: 'US' } }
+          ]
+        }]
+      }]
+    }
+  }
+};
+
+function stubFetch(overrides = {}) {
+  global.fetch = async (url) => {
+    const u = String(url);
+    for (const [needle, body] of Object.entries({ ...FIXTURES, ...overrides })) {
+      if (u.includes(needle)) {
+        if (body instanceof Error) return { ok: false, status: 401, text: async () => JSON.stringify({ error_description: body.message }) };
+        return { ok: true, status: 200, text: async () => JSON.stringify(body) };
+      }
+    }
+    throw new Error(`unstubbed URL: ${u}`);
+  };
+}
+
+test('USPS: events parse oldest-first with location, and summary drives status', async () => {
+  stubFetch();
+  const [r] = await carriers.trackAll([{ trackingNumber: '9400111899223197428490', carrier: 'usps' }], CONFIG);
+  assert.equal(r.error, null);
+  assert.equal(r.scans.length, 2);
+  assert.equal(r.scans[0].description, 'Accepted at USPS Origin Facility');
+  assert.equal(r.scans[1].description, 'In Transit to Next Facility');
+  assert.equal(r.scans[1].location, 'DES MOINES, IA');
+  assert.equal(statusOf(r), P.STATUS.IN_TRANSIT);
+});
+
+test('UPS: YYYYMMDD/HHMMSS becomes a sortable timestamp and D means delivered', async () => {
+  stubFetch();
+  const [r] = await carriers.trackAll([{ trackingNumber: '1Z999AA10123456784', carrier: 'ups' }], CONFIG);
+  assert.equal(r.error, null);
+  assert.deepEqual(r.scans.map(s => s.at), ['2026-08-26T06:12:00', '2026-08-26T14:23:00']);
+  assert.equal(r.scans[1].location, 'ATLANTA, GA, US');
+  assert.equal(statusOf(r), P.STATUS.DELIVERED);
+});
+
+test('FedEx: derivedCode OD is out-for-delivery, not merely in transit', async () => {
+  stubFetch();
+  const [r] = await carriers.trackAll([{ trackingNumber: '123456789012', carrier: 'fedex' }], CONFIG);
+  assert.equal(r.error, null);
+  assert.equal(r.scans.length, 2);
+  assert.equal(r.scans[0].description, 'Arrived at FedEx location');
+  assert.equal(statusOf(r), P.STATUS.OUT_FOR_DELIVERY);
+});
+
+test('a carrier with no credentials errors visibly instead of vanishing', async () => {
+  stubFetch();
+  const [r] = await carriers.trackAll(
+    [{ trackingNumber: '1Z999AA10123456784', carrier: 'ups' }],
+    { usps: CREDS, ups: { clientId: '', clientSecret: '' }, fedex: CREDS, portals: {} }
+  );
+  assert.match(r.error, /No ups API credentials/);
+  assert.deepEqual(r.scans, []);
+});
+
+test('an unknown carrier errors instead of being silently dropped', async () => {
+  stubFetch();
+  const [r] = await carriers.trackAll([{ trackingNumber: 'WHAT123', carrier: '' }], CONFIG);
+  assert.match(r.error, /Unknown carrier/);
+});
+
+test('an auth failure is reported per package, not thrown away', async () => {
+  stubFetch({ 'apis.fedex.com/oauth': new Error('invalid client') });
+  const rows = await carriers.trackAll([
+    { trackingNumber: '123456789012', carrier: 'fedex' },
+    { trackingNumber: '999999999999', carrier: 'fedex' }
+  ], CONFIG);
+  assert.equal(rows.length, 2);
+  for (const r of rows) assert.match(r.error, /invalid client/);
+});
+
+test('poller output merges cleanly into the registry', async () => {
+  stubFetch();
+  const [r] = await carriers.trackAll([{ trackingNumber: '1Z999AA10123456784', carrier: 'ups' }], CONFIG);
+  const snapshot = {
+    packages: [{ trackingNumber: r.trackingNumber, carrier: r.carrier, status: statusOf(r), scans: r.scans, source: 'api' }]
+  };
+  const existing = [P.newPackage({ description: 'Glock 19', trackingNumber: '1Z999AA10123456784' }, 'p1', '2026-08-01T00:00:00Z')];
+  const merged = P.mergeSnapshot(existing, snapshot, '2026-08-27T12:00:00Z', () => 'x');
+  assert.equal(merged.updated, 1);
+  assert.equal(merged.packages[0].status, P.STATUS.DELIVERED);
+  assert.equal(P.needsLogging(merged.packages[0]), true);
+});

--- a/apps/bound-book/tracker/config.example.json
+++ b/apps/bound-book/tracker/config.example.json
@@ -1,0 +1,7 @@
+{
+  "_comment": "Copy to config.json and fill in. config.json is gitignored. These are API client credentials from each carrier's DEVELOPER portal — never your consumer account password. Env vars BB_USPS_CLIENT_ID / BB_USPS_CLIENT_SECRET (and UPS_/FEDEX_ equivalents) override anything set here.",
+  "usps":  { "clientId": "", "clientSecret": "" },
+  "ups":   { "clientId": "", "clientSecret": "" },
+  "fedex": { "clientId": "", "clientSecret": "" },
+  "portals": { "usps": true, "ups": true, "fedex": true }
+}

--- a/apps/bound-book/tracker/package.json
+++ b/apps/bound-book/tracker/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "bound-book-tracker",
+  "private": true,
+  "description": "Inbound package poller for the Bound Book A&D record.",
+  "scripts": {
+    "poll": "node poll.js poll"
+  }
+}

--- a/apps/bound-book/tracker/poll.js
+++ b/apps/bound-book/tracker/poll.js
@@ -1,0 +1,238 @@
+#!/usr/bin/env node
+// poll.js — the Bound Book package poller.
+//
+//   node poll.js login <usps|ups|fedex>   one-time interactive sign-in
+//   node poll.js poll [options]           fetch status, write a snapshot
+//
+// The snapshot is a file you import in the app (Packages → Import snapshot).
+// Same round-trip as backup/restore: the browser app stays a double-click
+// page with no server and no secrets in it.
+//
+// Status always comes from the official carrier APIs. The portals are used
+// only to DISCOVER tracking numbers you never registered.
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const P = require('../packages.js');
+const carriers = require('./carriers.js');
+const portals = require('./portals.js');
+
+const CONFIG_PATH = path.join(__dirname, 'config.json');
+const DEFAULT_OUT = path.join(__dirname, 'package-snapshot.json');
+
+const USAGE = `
+Bound Book package poller
+
+  node poll.js login <usps|ups|fedex>
+      Open a browser, sign in yourself, save the session. Do this once per
+      carrier (and again whenever a session expires). No password is stored.
+
+  node poll.js poll [options]
+      --list <file>     tracking list exported from the app (Packages screen)
+      --numbers a,b,c   extra tracking numbers, comma separated
+      --out <file>      snapshot to write (default: package-snapshot.json)
+      --no-portals      skip portal discovery, use the carrier APIs only
+      --headed          run portal discovery in a visible browser
+      --dump            save portal page HTML + screenshot (for fixing selectors)
+
+  node poll.js --help
+`;
+
+function parseArgs(argv) {
+  const args = { command: 'poll', carrier: '', list: '', numbers: [], out: DEFAULT_OUT, portals: true, headed: false, dump: false };
+  const rest = argv.slice(2);
+  if (rest[0] && !rest[0].startsWith('--')) {
+    args.command = rest.shift();
+    if (args.command === 'login') args.carrier = rest.shift() || '';
+  }
+  for (let i = 0; i < rest.length; i++) {
+    const a = rest[i];
+    if (a === '--list') args.list = rest[++i];
+    else if (a === '--numbers') args.numbers = String(rest[++i] || '').split(',').map(s => s.trim()).filter(Boolean);
+    else if (a === '--out') args.out = rest[++i];
+    else if (a === '--no-portals') args.portals = false;
+    else if (a === '--headed') args.headed = true;
+    else if (a === '--dump') args.dump = true;
+    else if (a === '--help' || a === '-h') args.command = 'help';
+    else throw new Error(`Unknown option: ${a}`);
+  }
+  return args;
+}
+
+// config.json holds carrier API client ids/secrets. Env vars win, so you can
+// keep secrets out of the file entirely if you prefer.
+function loadConfig() {
+  let file = {};
+  if (fs.existsSync(CONFIG_PATH)) {
+    try {
+      file = JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf8'));
+    } catch (e) {
+      throw new Error(`config.json is not valid JSON: ${e.message}`);
+    }
+  }
+  const config = { portals: file.portals || {} };
+  for (const { key } of P.CARRIERS) {
+    const env = key.toUpperCase();
+    config[key] = {
+      clientId: process.env[`BB_${env}_CLIENT_ID`] || (file[key] && file[key].clientId) || '',
+      clientSecret: process.env[`BB_${env}_CLIENT_SECRET`] || (file[key] && file[key].clientSecret) || ''
+    };
+  }
+  return config;
+}
+
+// Registered packages come from the app's exported tracking list.
+function readList(file) {
+  if (!file) return [];
+  const data = JSON.parse(fs.readFileSync(file, 'utf8'));
+  const rows = Array.isArray(data) ? data : (data.packages || []);
+  return rows
+    .map(r => ({
+      trackingNumber: P.normalizeTracking(r.trackingNumber),
+      carrier: r.carrier || P.detectCarrier(r.trackingNumber)
+    }))
+    .filter(r => r.trackingNumber);
+}
+
+async function runDiscovery(config, known, opts) {
+  const enabled = P.CARRIERS
+    .map(c => c.key)
+    .filter(k => config.portals[k] !== false && portals.hasSession(k));
+
+  const skipped = P.CARRIERS.map(c => c.key).filter(k => config.portals[k] !== false && !portals.hasSession(k));
+  for (const k of skipped) {
+    console.log(`  ${portals.PORTALS[k].label}: no saved session — run 'node poll.js login ${k}'`);
+  }
+
+  const discovered = new Map();
+  for (const key of enabled) {
+    process.stdout.write(`  ${portals.PORTALS[key].label}: `);
+    const res = await portals.discover(key, opts);
+    if (res.error) { console.log(res.error); continue; }
+
+    let fresh = 0;
+    for (const hit of res.found) {
+      const carrier = P.detectCarrier(hit.trackingNumber);
+      // Dashboards are full of order numbers and phone numbers. If it does not
+      // look like a real tracking number, it is not one.
+      if (!carrier) continue;
+      if (known.has(hit.trackingNumber) || discovered.has(hit.trackingNumber)) continue;
+      discovered.set(hit.trackingNumber, { trackingNumber: hit.trackingNumber, carrier, context: hit.context });
+      fresh++;
+    }
+    console.log(`${res.found.length} number(s) on the page, ${fresh} new`);
+  }
+  return [...discovered.values()];
+}
+
+function statusOf(r) {
+  const last = r.scans && r.scans.length ? r.scans[r.scans.length - 1] : null;
+  return P.normalizeStatus(
+    r.carrier,
+    r.latestCode || (last && last.code) || '',
+    r.summary || (last && last.description) || ''
+  );
+}
+
+async function poll(args) {
+  const config = loadConfig();
+  const registered = readList(args.list).concat(
+    args.numbers.map(tn => ({ trackingNumber: P.normalizeTracking(tn), carrier: P.detectCarrier(tn) }))
+  );
+  const known = new Set(registered.map(r => r.trackingNumber));
+  console.log(`Registered packages to check: ${known.size}`);
+
+  let discovered = [];
+  if (args.portals) {
+    console.log('Portal discovery:');
+    discovered = await runDiscovery(config, known, { headed: args.headed, dump: args.dump });
+  }
+
+  const all = registered.concat(discovered.map(d => ({ trackingNumber: d.trackingNumber, carrier: d.carrier })));
+  if (!all.length) {
+    console.log('Nothing to track. Export a tracking list from the app, or pass --numbers.');
+    return;
+  }
+
+  console.log(`Querying carrier APIs for ${all.length} package(s)…`);
+  const results = await carriers.trackAll(all, config);
+
+  const contexts = new Map(discovered.map(d => [d.trackingNumber, d.context]));
+  const packages = [];
+  let errors = 0;
+  for (const r of results) {
+    const wasDiscovered = contexts.has(r.trackingNumber);
+    if (r.error) {
+      // Report it, but never write it to the snapshot: a discovered number
+      // that the carrier rejects was probably an order number the regex
+      // mistook for a tracking number, and junk should not reach the registry.
+      errors++;
+      console.log(`  ! ${r.trackingNumber}: ${r.error}`);
+      continue;
+    }
+    const row = {
+      trackingNumber: r.trackingNumber,
+      carrier: r.carrier,
+      status: statusOf(r),
+      scans: r.scans,
+      source: wasDiscovered ? 'portal' : 'api'
+    };
+    if (wasDiscovered) {
+      row.discovered = { description: contexts.get(r.trackingNumber) || '' };
+    }
+    packages.push(row);
+  }
+
+  const snapshot = {
+    app: 'bound-book-tracker',
+    version: 1,
+    polledAt: new Date().toISOString(),
+    packages
+  };
+  fs.writeFileSync(args.out, JSON.stringify(snapshot, null, 2));
+
+  const delivered = packages.filter(p => p.status === P.STATUS.DELIVERED).length;
+  console.log(`\nWrote ${packages.length} package(s) to ${path.relative(process.cwd(), args.out)}`);
+  console.log(`  ${delivered} delivered, ${packages.length - delivered} still moving, ${errors} error(s)`);
+  console.log('Import it in the app: Packages → Import snapshot.');
+}
+
+async function main() {
+  let args;
+  try {
+    args = parseArgs(process.argv);
+  } catch (e) {
+    console.error(e.message);
+    console.error(USAGE);
+    process.exit(1);
+  }
+
+  if (args.command === 'help') { console.log(USAGE); return; }
+
+  if (args.command === 'login') {
+    if (!portals.PORTALS[args.carrier]) {
+      console.error(`Usage: node poll.js login <${Object.keys(portals.PORTALS).join('|')}>`);
+      process.exit(1);
+    }
+    await portals.login(args.carrier);
+    return;
+  }
+
+  if (args.command !== 'poll') {
+    console.error(`Unknown command: ${args.command}`);
+    console.error(USAGE);
+    process.exit(1);
+  }
+  await poll(args);
+}
+
+if (require.main === module) {
+  main().catch(err => {
+    console.error(`\n${err.message}`);
+    process.exit(1);
+  });
+}
+
+module.exports = { statusOf, parseArgs, loadConfig };

--- a/apps/bound-book/tracker/portals.js
+++ b/apps/bound-book/tracker/portals.js
@@ -1,0 +1,170 @@
+// portals.js — discovery only. Signs in to Informed Delivery / UPS My Choice /
+// FedEx Delivery Manager and pulls the TRACKING NUMBERS visible on your
+// dashboard. It does not read status from these pages: status comes from the
+// official APIs (carriers.js), which are stable in a way portal HTML is not.
+//
+// Why numbers-only: the one thing that survives a portal redesign is the shape
+// of a tracking number. Scraping status out of a carrier's DOM breaks silently
+// the next time they ship a new dashboard; scraping numbers degrades to "found
+// none" instead, which is visible.
+//
+// Credentials: none are stored. `login` opens a real browser window, you sign
+// in yourself (MFA, captcha, whatever the carrier asks), and only the resulting
+// session cookies are saved to state/<carrier>.json — gitignored, and on your
+// machine only.
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const readline = require('node:readline');
+
+const STATE_DIR = path.join(__dirname, 'state');
+
+const PORTALS = {
+  usps: {
+    label: 'USPS Informed Delivery',
+    loginUrl: 'https://reg.usps.com/entreg/LoginAction_input',
+    dashboardUrl: 'https://informeddelivery.usps.com/box/pages/secure/DashboardAction_input.action',
+    loggedOut: /reg\.usps\.com|LoginAction|\/login/i
+  },
+  ups: {
+    label: 'UPS My Choice',
+    loginUrl: 'https://www.ups.com/lasso/login',
+    dashboardUrl: 'https://www.ups.com/mychoice/dashboard',
+    loggedOut: /lasso\/login|\/login|signin/i
+  },
+  fedex: {
+    label: 'FedEx Delivery Manager',
+    loginUrl: 'https://www.fedex.com/secure-login/en-us/',
+    dashboardUrl: 'https://www.fedex.com/fedextrack/dashboard',
+    loggedOut: /secure-login|\/login|signin/i
+  }
+};
+
+function statePath(carrier) {
+  return path.join(STATE_DIR, `${carrier}.json`);
+}
+
+function hasSession(carrier) {
+  return fs.existsSync(statePath(carrier));
+}
+
+function loadPlaywright() {
+  try {
+    return require('playwright');
+  } catch (e) {
+    throw new Error(
+      'Portal discovery needs Playwright. Install it in apps/bound-book/tracker:\n' +
+      '  npm install playwright && npx playwright install chromium\n' +
+      'Or run with --no-portals to use the carrier APIs only.'
+    );
+  }
+}
+
+function ask(question) {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise(resolve => rl.question(question, a => { rl.close(); resolve(a); }));
+}
+
+// Interactive one-time sign-in. Opens a visible browser, waits for you to
+// finish (including MFA), then saves the session.
+async function login(carrier) {
+  const portal = PORTALS[carrier];
+  if (!portal) throw new Error(`Unknown portal: ${carrier}`);
+  const { chromium } = loadPlaywright();
+
+  const browser = await chromium.launch({ headless: false });
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  await page.goto(portal.loginUrl, { waitUntil: 'domcontentloaded' });
+
+  console.log(`\nA browser window is open at ${portal.label}.`);
+  console.log('Sign in there as you normally would — password, MFA, all of it.');
+  console.log('Your password is never read by this tool; only the session cookies are saved.\n');
+  await ask('Press Enter here once you are signed in and looking at your dashboard… ');
+
+  fs.mkdirSync(STATE_DIR, { recursive: true });
+  await context.storageState({ path: statePath(carrier) });
+  await browser.close();
+  console.log(`Saved ${portal.label} session to ${path.relative(process.cwd(), statePath(carrier))}`);
+}
+
+// Pull tracking numbers off a portal dashboard using a saved session.
+async function discover(carrier, opts = {}) {
+  const portal = PORTALS[carrier];
+  if (!portal) throw new Error(`Unknown portal: ${carrier}`);
+  if (!hasSession(carrier)) {
+    return { carrier, found: [], error: `No saved session. Run: node poll.js login ${carrier}` };
+  }
+  const { chromium } = loadPlaywright();
+
+  const browser = await chromium.launch({ headless: !opts.headed });
+  try {
+    const context = await browser.newContext({ storageState: statePath(carrier) });
+    const page = await context.newPage();
+    await page.goto(portal.dashboardUrl, { waitUntil: 'domcontentloaded', timeout: 60000 });
+    await page.waitForLoadState('networkidle', { timeout: 30000 }).catch(() => {});
+
+    if (portal.loggedOut.test(page.url())) {
+      return { carrier, found: [], error: `Session expired. Run: node poll.js login ${carrier}` };
+    }
+
+    const found = await page.evaluate(scrapeTrackingNumbers);
+
+    if (opts.dump) {
+      fs.mkdirSync(STATE_DIR, { recursive: true });
+      const html = path.join(STATE_DIR, `${carrier}-dump.html`);
+      fs.writeFileSync(html, await page.content());
+      await page.screenshot({ path: path.join(STATE_DIR, `${carrier}-dump.png`), fullPage: true });
+      console.log(`  dumped page to ${path.relative(process.cwd(), html)} (+ .png)`);
+    }
+    return { carrier, found, error: null };
+  } catch (err) {
+    return { carrier, found: [], error: err.message };
+  } finally {
+    await browser.close();
+  }
+}
+
+// Runs inside the page. Self-contained by necessity — no closure over Node.
+// Walks text nodes for tracking-number-shaped strings and grabs a little
+// surrounding text as a human-readable description.
+function scrapeTrackingNumbers() {
+  const results = [];
+  const seen = new Set();
+  const LENGTHS = [12, 15, 20, 21, 22];
+
+  function push(raw, node) {
+    const tn = String(raw).replace(/[\s-]/g, '').toUpperCase();
+    if (seen.has(tn)) return;
+    seen.add(tn);
+    let el = node.parentElement;
+    let context = '';
+    for (let i = 0; i < 4 && el; i++) {
+      const t = (el.innerText || '').trim().replace(/\s+/g, ' ');
+      if (t.length > context.length) context = t;
+      if (context.length > 40) break;
+      el = el.parentElement;
+    }
+    results.push({ trackingNumber: tn, context: context.slice(0, 160) });
+  }
+
+  const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
+  let node;
+  while ((node = walker.nextNode())) {
+    const text = node.nodeValue || '';
+    if (!/\d/.test(text)) continue;
+    let m;
+    const alpha = /\b1Z[0-9A-Z]{16}\b|\b[A-Z]{2}\d{9}US\b/g;
+    while ((m = alpha.exec(text))) push(m[0], node);
+    const digits = /\d[\d\s-]{10,24}\d/g;
+    while ((m = digits.exec(text))) {
+      const bare = m[0].replace(/[\s-]/g, '');
+      if (LENGTHS.indexOf(bare.length) !== -1) push(bare, node);
+    }
+  }
+  return results;
+}
+
+module.exports = { PORTALS, login, discover, hasSession, statePath };

--- a/docs/bound-book-budget-prd.md
+++ b/docs/bound-book-budget-prd.md
@@ -1,0 +1,146 @@
+# Product Requirements — "Bound Book" Budget Tier
+
+**Audience:** Home-based, very small FFLs (Type 01 dealers run from home, Type 03 C&R collectors).
+**One-line pitch:** The cheapest way to keep a compliant Acquisition & Disposition (A&D) record — nothing more, nothing you don't need.
+**Status:** Draft for review.
+
+> **Not legal advice.** This spec summarizes federal recordkeeping rules (27 CFR Part 478) to scope the product. Confirm current ATF requirements and any state rules with counsel or your ATF Industry Operations office before shipping. Rules change; the code must not hardcode assumptions that go stale silently.
+
+---
+
+## 1. Problem & Opportunity
+
+A licensee must maintain a bound A&D record. Full firearms-retail software (POS, e-4473, inventory, labels, accounting) is overkill and overpriced for someone doing a handful of transfers a year from home. That segment wants one thing: **stay compliant, cheaply.**
+
+A "bound book only" tier is a clean, well-bounded slice of that market. The discipline of this tier is: **strip features aggressively, never strip compliance.**
+
+## 2. Goals / Non-Goals
+
+**Goals**
+- Record acquisitions and dispositions with every ATF-required field.
+- Produce a searchable ledger and an ATF-ready export/print on demand.
+- Preserve record integrity and retention.
+- Be dramatically simpler and cheaper than full FFL suites.
+
+**Non-Goals (explicitly out of the budget tier)**
+- Point-of-sale / payments
+- Integrated e-4473 (separate, heavier regulated workflow)
+- Multi-user roles, multi-location
+- Barcode/label hardware, scanners
+- Accounting, tax, sales reporting
+- Inventory valuation / merchandising
+
+These become optional paid add-ons later, not part of the floor.
+
+## 3. The Compliance Floor (non-negotiable, even at $0)
+
+Per firearm the record must capture:
+
+**Acquisition**
+- Date received
+- Manufacturer and/or importer
+- Model
+- Serial number
+- Type (e.g., pistol, rifle, receiver)
+- Caliber / gauge
+- Source: name + address, or FFL number if from a licensee
+
+**Disposition**
+- Date of disposition
+- Buyer/transferee name + address (or FFL number)
+- 4473 form serial / transfer reference
+- Eligibility documentation trail (the fact that a background check / 4473 was completed and where that paperwork lives)
+
+**Cross-cutting integrity requirements**
+- **Retention:** records must be preserved (long-horizon — treat as permanent) and be surrenderable to ATF on license discontinuance.
+- **No silent mutation:** entries must not be quietly deleted or overwritten. Corrections follow the "line-out, don't erase" convention — keep the original visible and append the correction with a timestamp and reason.
+- **Chronological, gap-free ordering** of entries.
+- **Export on demand:** ATF-consumable output (print + PDF + CSV).
+
+If a feature cut would violate any bullet in this section, it is not on the table for the budget tier.
+
+## 4. The Key Decision — Legal Role of the Software (advisory)
+
+You asked which role to pick. Here is the tradeoff and my recommendation.
+
+### Option A — Companion / printable ledger (**recommended for the budget tier**)
+The app helps you *keep* the record, but the **printed (or exported PDF) ledger is the official ATF record**. The user prints, signs where required, and stores paper.
+
+- **Pros:** Lowest compliance risk and lowest build cost. No ATF electronic-recordkeeping variance/approval needed. Integrity burden is mostly "generate a clean, correct printout." Perfect fit for someone doing low volume from home.
+- **Cons:** User still handles paper. The app is an aid, not the sole legal system.
+- **Why it fits:** A budget, home-based FFL is exactly the user who is fine printing a ledger and does not want the obligations of a fully electronic system of record.
+
+### Option B — Electronic system of record
+The app **is** the legal bound book; no paper.
+
+- **Pros:** Fully paperless, higher perceived value.
+- **Cons:** ATF imposes specific conditions on electronic A&D systems (typically prior approval/variance, guaranteed no data gaps, tamper-evidence, reliable reproduction on demand, defined backup/continuity). Materially more to build, test, and stand behind legally. Overkill for the budget persona.
+
+### Recommendation
+Originally: **ship Option A** and design so upgrading to Option B is a
+positioning + hardening step, not a rewrite. That path was followed — the
+integrity features were built on the append-only model from the start.
+
+**Update:** the ATF variance is now **approved**, so the product operates as
+**Option B — an electronic system of record** (see the section below). The
+Option A analysis is retained for history and because the print/PDF/CSV output
+it describes still serves as the human-readable surrender copy.
+
+### Option B — in effect (variance approved)
+
+The ATF variance is **approved**, so the app now operates as the **electronic
+system of record**. The requirements are met as follows:
+
+- **Tamper-evidence** — an append-only, **hash-chained event log**
+  (`integrity.js`): every action (acquire, dispose, correct) is an immutable
+  event; the ledger is a *projection* of the log, never edited in place. Each
+  event hashes its contents plus the previous event's hash, so any after-the-fact
+  edit, deletion, or reorder breaks the chain and is detected.
+- **No data gaps** — sequential numbering verified on demand (the **Integrity**
+  screen).
+- **Reproduction on demand** — Print / Save-as-PDF and CSV export produce the
+  human-readable / surrender copy.
+- **Backup & continuity** — full-fidelity JSON backup of the entire chained log,
+  with **verify-on-restore**: a tampered or corrupt backup fails the integrity
+  check and is refused rather than loaded. Because the build is local-first, the
+  user's backup is the continuity + surrender copy; regular backup is now a
+  compliance step, surfaced in the first-run notice and on the Integrity screen.
+
+Print/PDF/CSV remain available as the human-readable surrender copies, but they
+are no longer the *system of record* — the chained log is.
+
+This gives budget users what they need today and preserves your upgrade path.
+
+## 5. Scope — Screens (target: ~4)
+
+1. **Acquire** — form to log an incoming firearm (all Acquisition fields).
+2. **Dispose** — select an open (undisposed) firearm, log the Disposition fields.
+3. **Ledger** — chronological, searchable/filterable list; shows open vs. closed entries; correction history visible.
+4. **Export / Print** — generate ATF-ready PDF, printable ledger, and CSV backup.
+
+Supporting (not full screens): simple licensee profile (name, FFL#, address for headers), and a first-run disclaimer.
+
+## 6. Data Model (sketch)
+
+- **Firearm/Entry** (one row = one firearm's lifecycle)
+  - `id`, acquisition fields, disposition fields (nullable until disposed), `status` (open/disposed), `created_at`.
+- **Correction** (append-only)
+  - `entry_id`, `field`, `old_value`, `new_value`, `reason`, `corrected_at`. Never mutate the original field in place — render the line-out from these records.
+- **LicenseeProfile** — header data for exports.
+
+Integrity rules enforced at the data layer: no hard deletes of entries; edits to regulated fields go through the Correction append path.
+
+## 7. Success Criteria
+
+- A user can log an acquisition, later log its disposition, and produce a PDF that contains **every** required field in ATF-acceptable form.
+- No regulated field can be silently deleted or overwritten; every correction is visible with timestamp + reason.
+- Full ledger exports to CSV for backup and to PDF for ATF.
+- Zero features from the Non-Goals list ship in this tier.
+
+## 8. Open Questions
+
+1. **State-level rules** — any target states with extra logging (e.g., specific record formats, additional retention)? Budget tier may need a "state notes" flag.
+2. **Multi-firearm transactions** — support acquiring several firearms in one entry session, or strictly one-at-a-time to keep it simple?
+3. **Backup responsibility** — is CSV/PDF export enough for v1, or do we owe an automated backup story even at the budget tier?
+4. **Distribution** — desktop/local-first (data stays on the user's machine, good for a privacy-sensitive audience) vs. hosted? Local-first pairs well with Option A.
+5. **Upgrade path** — confirm we're committing to the Option A→B migration path so the integrity work isn't wasted.


### PR DESCRIPTION
## Changes

- Add `$schema` field to match Claude Code marketplace schema
- Promote `description` from nested `metadata` object to top level
- Remove non-standard `id` field

## Why

The previous `marketplace.json` had a non-standard `id` field and nested `description` inside a `metadata` wrapper. The Claude Code `/plugin marketplace add` parser expects `description` at the top level per the official schema (`https://anthropic.com/claude-code/marketplace.schema.json`). This fix makes the two-step install work correctly:

```
/plugin marketplace add forrestchang/andrej-karpathy-skills
/plugin install andrej-karpathy-skills@karpathy-skills
```