### PR TITLE
fix(docs): make test-first sorting example actually reproduce the bug

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -453,12 +453,12 @@ Start with step 1?
 
 ### Example 3: Test-First Verification
 
-**User Request:** "The sorting breaks when there are duplicate scores"
+**User Request:** "The sorting breaks when there are duplicate scores — tied scores should be ordered alphabetically by name"
 
 **❌ What LLMs Do (Fix Without Reproducing)**
 
 ```python
-# Immediately changes sort logic without confirming the bug
+# Immediately changes sort logic without first reproducing the bug
 def sort_scores(scores):
     return sorted(scores, key=lambda x: (-x['score'], x['name']))
 ```
@@ -466,31 +466,37 @@ def sort_scores(scores):
 **✅ What Should Happen (Reproduce First)**
 
 ```python
+# Existing implementation sorts by score descending.
+# Python's stable sort preserves input order when scores are tied.
+def sort_scores(scores):
+    return sorted(scores, key=lambda x: -x['score'])
+
 # 1. First, write a test that reproduces the issue
 def test_sort_with_duplicate_scores():
-    """Test sorting when multiple items have same score."""
+    """Test alphabetical ordering when multiple items have the same score."""
     scores = [
-        {'name': 'Alice', 'score': 100},
         {'name': 'Bob', 'score': 100},
+        {'name': 'Alice', 'score': 100},
         {'name': 'Charlie', 'score': 90},
     ]
-    
+
     result = sort_scores(scores)
-    
-    # The bug: order is non-deterministic for duplicates
-    # Run this test multiple times, it should be consistent
-    assert result[0]['score'] == 100
-    assert result[1]['score'] == 100
-    assert result[2]['score'] == 90
 
-# Verify: Run test 10 times → fails with inconsistent ordering
+    # Expected behavior: ties are ordered alphabetically by name
+    assert [item['name'] for item in result] == [
+        'Alice',
+        'Bob',
+        'Charlie',
+    ]
 
-# 2. Now fix with stable sort
+# Verify: Test fails → result is Bob, Alice, Charlie
+
+# 2. Now fix the tie ordering
 def sort_scores(scores):
     """Sort by score descending, then name ascending for ties."""
     return sorted(scores, key=lambda x: (-x['score'], x['name']))
 
-# Verify: Test passes consistently
+# Verify: The same test now passes
 ```
 
 ---


### PR DESCRIPTION
## Summary

Fix the `Goal-Driven Execution` test-first verification example in `EXAMPLES.md` so it demonstrates a genuine **failing verification → minimal fix → passing verification** cycle.

## Problem

The existing duplicate-score example intends to demonstrate the principle:

> reproduce the bug first, then fix it and verify the result.

However, the example itself does not currently reproduce the behavior it describes.

Specifically:

* the test checks only the resulting score values, so it cannot detect incorrect ordering between entries with equal scores;
* the example describes the tied ordering as non-deterministic, even though Python's sort is stable and preserves the original order of equal-key items;
* the implementation shown before the fix already uses the same score/name tie-breaker as the implementation shown after the fix.

As a result, the example does not provide an actual red → green verification cycle.

## What changed

The example now defines the expected behavior explicitly:

**When scores are tied, entries should be ordered alphabetically by name.**

It then demonstrates the full verification flow:

1. The existing implementation sorts only by score descending.
2. The input intentionally places `Bob` before `Alice` with the same score.
3. The test asserts the resulting **name order**, rather than only checking duplicate score values.
4. The test fails against the existing implementation with:
   `Bob, Alice, Charlie`.
5. The minimal fix adds `name` as the secondary sort key.
6. The same test then passes with:
   `Alice, Bob, Charlie`.

The wording was also updated to describe Python's stable tie ordering accurately rather than calling it non-deterministic.

## Why this matters

`Goal-Driven Execution` is about turning vague work into observable success criteria and verifying progress against them.

A test-first example should therefore itself be verifiable.

With this change, the example now demonstrates the exact behavior it recommends:

```text
Define expected behavior
        ↓
Reproduce the failure
        ↓
Make the smallest fix
        ↓
Run the same verification
        ↓
Confirm success
```

## Scope

This is intentionally a surgical documentation fix.

* Only the affected `Test-First Verification` example is changed.
* No new principles are introduced.
* No changes are made to `CLAUDE.md`, skill definitions, Cursor rules, plugin metadata, or unrelated examples.

## Validation

* Confirmed the score-only sort produces `Bob, Alice, Charlie`.
* Confirmed the score/name tie-breaker produces `Alice, Bob, Charlie`.
* Confirmed the pre-fix behavior fails the updated ordering assertion.
* Confirmed the corrected implementation satisfies the same assertion.
* Reviewed the change to ensure the example remains consistent with the existing `EXAMPLES.md` structure and style.
