### PR TITLE
feat: add DSH (DeepSeek Harness) bundle plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,21 @@ Then install the plugin:
 
 This installs the guidelines as a Claude Code plugin, making the skill available across all your projects.
 
-**Option B: CLAUDE.md (per-project)**
+**Option B: DeepSeek Harness (DSH) Plugin**
+
+Install as a DSH skill bundle:
+
+```bash
+# Via npm
+dsh plugin --profile web add dsh-skill-andrej-karpathy
+
+# Or via GitHub
+dsh plugin --profile web add "github:multica-ai/andrej-karpathy-skills#main&path:/dsh-bundle"
+```
+
+After installation, restart DSH web. The `andrej-karpathy-coding-guidelines` skill will be available in all sessions.
+
+**Option C: CLAUDE.md (per-project)**
 
 New project:
 ```bash

--- a/README.zh.md
+++ b/README.zh.md
@@ -112,7 +112,21 @@ LLM 经常默默选择一种解释然后执行。这个原则强制明确推理�
 
 这会将指南安装为 Claude Code 插件，使其在你所有项目中可用。
 
-**选项 B：CLAUDE.md（按项目）**
+**选项 B：DeepSeek Harness (DSH) 插件**
+
+安装为 DSH skill bundle：
+
+```bash
+# 通过 npm
+dsh plugin --profile web add dsh-skill-andrej-karpathy
+
+# 或通过 GitHub
+dsh plugin --profile web add "github:multica-ai/andrej-karpathy-skills#main&path:/dsh-bundle"
+```
+
+安装后重启 DSH web，`andrej-karpathy-coding-guidelines` skill 将在所有会话中可用。
+
+**选项 C：CLAUDE.md（按项目）**
 
 新项目：
 ```bash

--- a/dsh-bundle/README.md
+++ b/dsh-bundle/README.md
@@ -1,0 +1,53 @@
+# DSH Skill: Andrej Karpathy Coding Guidelines
+
+> Andrej Karpathy inspired coding guidelines as a DSH skill bundle. Reduces common LLM coding mistakes through four principles: Think Before Coding, Simplicity First, Surgical Changes, and Goal-Driven Execution.
+
+## Installation
+
+```bash
+dsh plugin --profile web add dsh-skill-andrej-karpathy
+```
+
+Or install from GitHub:
+
+```bash
+dsh plugin --profile web add "github:multica-ai/andrej-karpathy-skills#<ref>&path:/dsh-bundle"
+```
+
+After installation, **restart DSH web** for the skill to take effect.
+
+## Features
+
+Installs a global skill `andrej-karpathy-coding-guidelines` that guides the agent to:
+
+| Principle | What it does |
+|-----------|-------------|
+| **Think Before Coding** | Explicit assumptions, present interpretations, push back, ask when confused |
+| **Simplicity First** | Minimum code, no speculative features, no unnecessary abstractions |
+| **Surgical Changes** | Touch only what's needed, match existing style, clean up own orphans only |
+| **Goal-Driven Execution** | Define verifiable success criteria, test-first, loop until verified |
+
+## Development
+
+### Local Testing
+
+```bash
+cd dsh-bundle
+dsh plugin --profile web add .
+```
+
+### File Structure
+
+```
+dsh-bundle/
+├── package.json          # npm package + dsh.bundle/dsh.skills declarations
+├── cordis.patch.yml      # Bundle patch: inserts skill-filesystem provider
+├── index.mjs             # Node half entry (Cordis plugin)
+└── skills/
+    └── andrej-karpathy-coding-guidelines/
+        └── SKILL.md      # Skill content
+```
+
+## License
+
+MIT

--- a/dsh-bundle/cordis.patch.yml
+++ b/dsh-bundle/cordis.patch.yml
@@ -1,0 +1,14 @@
+# dsh-skill-andrej-karpathy bundle patch
+# 
+# This patch inserts the skill-filesystem provider with customSkillDirs
+# pointing to this bundle's skills/ directory.
+
+- insert:
+    - id: skill-filesystem-andrej-karpathy
+      name: '@deepseek-ai/dsh-skill-filesystem'
+      config:
+        providerName: filesystem-andrej-karpathy
+        includeDefaultRoots: false
+        customSkillDirs:
+          - !!js require('path').join(require('path').dirname(require.resolve('dsh-skill-andrej-karpathy/package.json')), 'skills')
+        watch: true

--- a/dsh-bundle/index.mjs
+++ b/dsh-bundle/index.mjs
@@ -1,0 +1,11 @@
+// DSH Skill Bundle - Andrej Karpathy Coding Guidelines
+// Node half entry: Cordis plugin
+
+export const name = 'dsh-skill-andrej-karpathy'
+
+// No runtime logic needed - skills are loaded by dsh-skill-filesystem
+// The cordis.patch.yml configures the filesystem provider to scan our skills/ directory
+export function apply(ctx) {
+  // Skills are declarative - loaded via dsh.skills in package.json
+  // and discovered by the skill-filesystem provider
+}

--- a/dsh-bundle/package.json
+++ b/dsh-bundle/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "dsh-skill-andrej-karpathy",
+  "version": "1.0.0",
+  "description": "Andrej Karpathy inspired coding guidelines as a DSH skill bundle. Reduces common LLM coding mistakes through four principles: Think Before Coding, Simplicity First, Surgical Changes, and Goal-Driven Execution.",
+  "type": "module",
+  "main": "./index.mjs",
+  "exports": {
+    ".": "./index.mjs",
+    "./cordis.patch.yml": "./cordis.patch.yml",
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "index.mjs",
+    "cordis.patch.yml",
+    "skills/**/*"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/multica-ai/andrej-karpathy-skills.git"
+  },
+  "keywords": [
+    "dsh",
+    "dsh-bundle",
+    "deepseek-harness",
+    "skill",
+    "andrej-karpathy",
+    "coding-guidelines",
+    "llm",
+    "agent"
+  ],
+  "dsh": {
+    "bundle": {
+      "patch": "./cordis.patch.yml"
+    },
+    "skills": [
+      "./skills/andrej-karpathy-coding-guidelines/SKILL.md"
+    ]
+  }
+}

--- a/dsh-bundle/skills/andrej-karpathy-coding-guidelines/SKILL.md
+++ b/dsh-bundle/skills/andrej-karpathy-coding-guidelines/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: andrej-karpathy-coding-guidelines
+description: Use this skill when writing, editing, or reviewing code to avoid common LLM coding mistakes. Guides the agent to think before coding, prefer simplicity, make surgical changes only, and define verifiable success criteria. Derived from Andrej Karpathy's observations on LLM coding pitfalls.
+---
+
+# Andrej Karpathy Coding Behavior Guidelines
+
+> Source: [Andrej Karpathy's observations](https://x.com/karpathy/status/2015883857489522876) on LLM coding pitfalls.
+> Original project: [multica-ai/andrej-karpathy-skills](https://github.com/multica-ai/andrej-karpathy-skills)
+
+## The Problem
+
+From Andrej's tweets:
+
+> "Models make wrong assumptions on your behalf and then execute without hesitation. They don't manage their own confusion, don't seek clarification, don't surface contradictions, don't present tradeoffs, and don't push back when they should."
+
+> "They really like to overcomplicate code and APIs, pile up abstractions, not clean up dead code... turning 100-line solutions into 1000-line bloated architectures."
+
+> "They still sometimes modify or delete code and comments they don't fully understand, even when unrelated to the task."
+
+## The Solution
+
+Four principles that directly address these problems:
+
+| Principle | Solves |
+|-----------|--------|
+| **Think Before Coding** | Wrong assumptions, hidden confusion, missing tradeoffs |
+| **Simplicity First** | Over-engineering, bloated abstractions |
+| **Surgical Changes** | Unrelated edits, touching what shouldn't be touched |
+| **Goal-Driven Execution** | Test-first, verifiable success criteria |
+
+---
+
+## 1. Think Before Coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+LLMs often silently pick one interpretation and execute. This principle forces explicit reasoning:
+
+- **State assumptions explicitly** — If uncertain, ask rather than guess
+- **Present multiple interpretations** — When ambiguity exists, don't pick silently
+- **Push back when warranted** — If a simpler approach exists, say so
+- **Stop when confused** — Name what's confusing. Ask.
+
+---
+
+## 2. Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+Counter the tendency to over-engineer:
+
+- No features beyond what was asked
+- No abstractions for single-use code
+- No "flexibility" or "configurability" that wasn't requested
+- No error handling for impossible scenarios
+- If you write 200 lines and it could be 50, rewrite it
+
+**Test:** Would a senior engineer say this is overcomplicated? If yes, simplify.
+
+---
+
+## 3. Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+
+- Don't "improve" adjacent code, comments, or formatting
+- Don't refactor things that aren't broken
+- Match existing style, even if you'd do it differently
+- If you notice unrelated dead code, mention it — don't delete it
+
+When your changes create orphans:
+
+- Remove imports/variables/functions that YOUR changes made unused
+- Don't remove pre-existing dead code unless asked
+
+**Test:** Every changed line should trace directly to the user's request.
+
+---
+
+## 4. Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform imperative tasks into verifiable goals:
+
+| Don't say... | Transform to... |
+|-------------|-----------------|
+| "Add validation" | "Write tests for invalid inputs, then make them pass" |
+| "Fix the bug" | "Write a test that reproduces it, then make it pass" |
+| "Refactor X" | "Ensure tests pass before and after" |
+
+For multi-step tasks, state a brief plan:
+
+```
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+```
+
+Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
+
+---
+
+## Usage Notes
+
+**Tradeoff:** These guidelines bias toward caution over speed. For trivial tasks, use judgment.
+
+**Signs these guidelines are working:** Fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.


### PR DESCRIPTION
## 新增 DSH 插件支持

为 DeepSeek Harness (DSH) 用户添加了官方 bundle 插件，使 Andrej Karpathy 编码指南可以作为全局 skill 使用。

### 安装方式

**通过 npm:**
```bash
dsh plugin --profile web add dsh-skill-andrej-karpathy
```

**通过 GitHub:**
```bash
dsh plugin --profile web add "github:multica-ai/andrej-karpathy-skills#main&path:/dsh-bundle"
```

### 变更内容

- 新增 dsh-bundle/ 目录，包含完整的 DSH bundle 插件
- 更新 README.md 和 README.zh.md，添加 DSH 安装说明
- 遵循 DSH 官方 bundle 插件规范

### 文件结构

dsh-bundle/
├── package.json
├── cordis.patch.yml
├── index.mjs
├── README.md
└── skills/
    └── andrej-karpathy-coding-guidelines/
        └── SKILL.md

### 测试

- [x] 本地测试通过
- [x] npm 包已发布：https://www.npmjs.com/package/dsh-skill-andrej-karpathy