### PR TITLE
docs: add Codex support and refresh READMEs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,70 @@
+# AGENTS.md
+
+Behavioral guidelines to reduce common coding-agent mistakes. Merge with project-specific instructions as needed.
+
+**Tradeoff:** These guidelines bias toward caution over speed. For trivial tasks, use judgment.
+
+## 1. Think Before Coding
+
+**Do not assume. Do not hide confusion. Surface tradeoffs.**
+
+Before implementing:
+
+- State important assumptions explicitly. If uncertainty would materially change the solution, ask.
+- If multiple interpretations are plausible, present them instead of choosing silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop and name what is missing.
+
+## 2. Simplicity First
+
+**Write the minimum code that solves the stated problem. Nothing speculative.**
+
+- Do not add features beyond what was requested.
+- Do not create abstractions for single-use code.
+- Do not add flexibility or configurability for hypothetical future needs.
+- Do not add error handling for impossible scenarios.
+- If 200 lines can clearly be 50, simplify.
+
+Ask: “Would a senior engineer say this is overcomplicated?” If yes, simplify.
+
+## 3. Surgical Changes
+
+**Touch only what the task requires. Clean up only what your change makes obsolete.**
+
+When editing existing code:
+
+- Do not improve adjacent code, comments, names, or formatting without a task-related reason.
+- Do not refactor code that is unrelated to the requested outcome.
+- Match the existing style and patterns.
+- If you notice unrelated dead code or defects, mention them instead of silently changing them.
+
+When your changes create orphans:
+
+- Remove imports, variables, or functions that your own change made unused.
+- Do not remove pre-existing dead code unless asked.
+
+The test: every changed line should trace directly to the request or to verification of the requested behavior.
+
+## 4. Goal-Driven Execution
+
+**Define observable success criteria. Loop until they are verified.**
+
+Transform tasks into verifiable goals:
+
+- “Add validation” -> “Add tests for invalid inputs, then make them pass.”
+- “Fix the bug” -> “Write a test that reproduces it, then make it pass.”
+- “Refactor X” -> “Establish passing checks before and after the refactor.”
+
+For multi-step tasks, pair each step with its check:
+
+```text
+1. [Step] -> verify: [check]
+2. [Step] -> verify: [check]
+3. [Step] -> verify: [check]
+```
+
+Strong success criteria let the agent loop independently. Weak criteria such as “make it work” require clarification before implementation.
+
+---
+
+**These guidelines are working if:** diffs contain fewer unrelated changes, solutions contain less speculative complexity, clarifying questions happen before implementation, and completion reports name the checks that actually ran.

--- a/CODEX.md
+++ b/CODEX.md
@@ -1,0 +1,107 @@
+# Using This Repository with OpenAI Codex
+
+This repository supports Codex in two complementary forms:
+
+- [`AGENTS.md`](AGENTS.md) provides always-on instructions at global or project scope.
+- [`skills/karpathy-guidelines/SKILL.md`](skills/karpathy-guidelines/SKILL.md) provides a reusable skill that can be invoked explicitly or selected when relevant.
+
+Use `AGENTS.md` when you want the four principles applied to every coding task in scope. Use the skill when you want opt-in or task-matched behavior.
+
+## In This Repository
+
+No setup is required. Codex reads the root [`AGENTS.md`](AGENTS.md) before working in this repository.
+
+To confirm which guidance is active, start a new Codex run from the repository root:
+
+```bash
+codex --ask-for-approval never "Summarize the current instructions."
+```
+
+## Use the Guidelines in One Project
+
+If the target project does not already contain `AGENTS.md`, download it at the project root.
+
+macOS, Linux, or Git Bash:
+
+```bash
+curl -L https://raw.githubusercontent.com/multica-ai/andrej-karpathy-skills/main/AGENTS.md -o AGENTS.md
+```
+
+Windows PowerShell:
+
+```powershell
+Invoke-WebRequest -Uri "https://raw.githubusercontent.com/multica-ai/andrej-karpathy-skills/main/AGENTS.md" -OutFile "AGENTS.md"
+```
+
+If `AGENTS.md` already exists, review both files and merge the four behavioral sections. Do not replace existing project setup, test commands, architecture notes, or safety rules.
+
+Codex walks from the repository root toward the current working directory, so nested `AGENTS.md` or `AGENTS.override.md` files can add more specific instructions for a subdirectory.
+
+## Use the Guidelines in Every Codex Project
+
+Codex reads global guidance from `~/.codex/AGENTS.md` unless `~/.codex/AGENTS.override.md` is present. On Windows, the default path is `%USERPROFILE%\.codex\AGENTS.md`.
+
+If the global file does not exist, create it from this repository.
+
+macOS or Linux:
+
+```bash
+mkdir -p ~/.codex
+curl -L https://raw.githubusercontent.com/multica-ai/andrej-karpathy-skills/main/AGENTS.md -o ~/.codex/AGENTS.md
+```
+
+Windows PowerShell:
+
+```powershell
+$codexDir = Join-Path $env:USERPROFILE ".codex"
+New-Item -ItemType Directory -Force -Path $codexDir | Out-Null
+Invoke-WebRequest -Uri "https://raw.githubusercontent.com/multica-ai/andrej-karpathy-skills/main/AGENTS.md" -OutFile (Join-Path $codexDir "AGENTS.md")
+```
+
+If the global file already exists, back it up and merge the guidelines manually. Project-level files are loaded after global guidance and can provide repository-specific rules.
+
+Start a new Codex session after changing instruction files, then verify:
+
+```bash
+codex --ask-for-approval never "List the instruction sources you loaded and summarize their guidance."
+```
+
+## Install as a Reusable Skill
+
+In Codex, ask the built-in installer to install the skill from this repository:
+
+```text
+$skill-installer Install karpathy-guidelines from https://github.com/multica-ai/andrej-karpathy-skills/tree/main/skills/karpathy-guidelines
+```
+
+Codex detects newly installed skills automatically. If the skill is not listed, restart Codex. You can then:
+
+- Type `$karpathy-guidelines` to invoke it explicitly.
+- Use `/skills` in Codex CLI or the IDE extension to inspect available skills.
+- Let Codex select it automatically when the task matches its description.
+
+## Choose the Right Scope
+
+| Desired behavior | Recommended setup |
+| --- | --- |
+| Apply to every coding task in every repository | Merge into global `~/.codex/AGENTS.md` |
+| Apply automatically in one repository | Add or merge root `AGENTS.md` |
+| Apply automatically in one subdirectory | Add nested `AGENTS.md` or `AGENTS.override.md` |
+| Invoke only when useful | Install `karpathy-guidelines` as a skill |
+
+## Troubleshooting
+
+- **Nothing loads:** Confirm that Codex is running from the intended repository and that the instruction file is not empty.
+- **Unexpected guidance wins:** Look for `AGENTS.override.md` in the Codex home directory or closer to the current working directory.
+- **Changes look stale:** Start a new run or restart the current Codex session; instructions are discovered at the beginning of a run.
+- **The skill is missing:** Run `/skills`, check the installer result, and restart Codex if necessary.
+- **Existing project rules disappeared:** Restore the previous file and merge instead of overwriting.
+
+## Official Documentation
+
+- [Custom instructions with AGENTS.md](https://developers.openai.com/codex/guides/agents-md/)
+- [Build and install Codex skills](https://developers.openai.com/codex/skills/)
+
+## For Contributors
+
+When the principles change, keep [`AGENTS.md`](AGENTS.md), [`CLAUDE.md`](CLAUDE.md), [`skills/karpathy-guidelines/SKILL.md`](skills/karpathy-guidelines/SKILL.md), and [`.cursor/rules/karpathy-guidelines.mdc`](.cursor/rules/karpathy-guidelines.mdc) behaviorally aligned.

--- a/CURSOR.md
+++ b/CURSOR.md
@@ -18,11 +18,12 @@ This project includes a **Cursor project rule** so the Karpathy-inspired behavio
 
 If you want the same content as a reusable skill under `~/.cursor/skills`, use [`skills/karpathy-guidelines/SKILL.md`](skills/karpathy-guidelines/SKILL.md). You can copy or symlink it into your personal skills directory; use whatever layout you use for other skills.
 
-## Claude Code vs Cursor
+## Claude Code, Codex, and Cursor
 
 - **Claude Code:** Install via the plugin marketplace and [`README.md`](README.md) instructions; the plugin exposes the skill from this repo. Per-project use can also rely on `CLAUDE.md`.
+- **OpenAI Codex:** Use [`AGENTS.md`](AGENTS.md) for always-on instructions or install [`skills/karpathy-guidelines/SKILL.md`](skills/karpathy-guidelines/SKILL.md) as a reusable skill. See [`CODEX.md`](CODEX.md).
 - **Cursor:** Use the committed `.cursor/rules/` file as described above. Cursor does not read `.claude-plugin/` or `CLAUDE.md` by default.
 
 ## For contributors
 
-When you change the four principles, keep **[`CLAUDE.md`](CLAUDE.md)** and **[`.cursor/rules/karpathy-guidelines.mdc`](.cursor/rules/karpathy-guidelines.mdc)** in sync. If the published skill/plugin text should match, update **[`skills/karpathy-guidelines/SKILL.md`](skills/karpathy-guidelines/SKILL.md)** as well.
+When you change the four principles, keep **[`AGENTS.md`](AGENTS.md)**, **[`CLAUDE.md`](CLAUDE.md)**, **[`.cursor/rules/karpathy-guidelines.mdc`](.cursor/rules/karpathy-guidelines.mdc)**, and **[`skills/karpathy-guidelines/SKILL.md`](skills/karpathy-guidelines/SKILL.md)** behaviorally aligned.

--- a/README.md
+++ b/README.md
@@ -1,170 +1,215 @@
-# Karpathy-Inspired Claude Code Guidelines
+# Karpathy-Inspired Coding Agent Guidelines
 
-> Check out my new project [Multica](https://github.com/multica-ai/multica) — an open-source platform for running and managing coding agents with reusable skills.
->
-> Follow me on X: [https://x.com/jiayuan_jy](https://x.com/jiayuan_jy)
+Portable behavioral guidelines for coding agents, derived from [Andrej Karpathy's observations](https://x.com/karpathy/status/2015883857489522876) about common LLM coding failures.
 
-A single `CLAUDE.md` file to improve Claude Code behavior, derived from [Andrej Karpathy's observations](https://x.com/karpathy/status/2015883857489522876) on LLM coding pitfalls.
+Use the same four principles in **Claude Code**, **OpenAI Codex**, **Cursor**, or any agent that supports project instructions or Agent Skills.
 
-English | [简体中文](./README.zh.md)
+English | [简体中文](README.zh.md)
 
-## The Problems
+> Also see [Multica](https://github.com/multica-ai/multica), an open-source platform for running coding agents with reusable skills.
 
-From Andrej's post:
+## Why This Exists
 
-> "The models make wrong assumptions on your behalf and just run along with them without checking. They don't manage their confusion, don't seek clarifications, don't surface inconsistencies, don't present tradeoffs, don't push back when they should."
+Coding agents are capable, but they often fail in predictable ways: they silently assume, overengineer, modify unrelated code, and declare success without proving the result.
 
-> "They really like to overcomplicate code and APIs, bloat abstractions, don't clean up dead code... implement a bloated construction over 1000 lines when 100 would do."
+This repository turns those failure modes into four concrete working agreements:
 
-> "They still sometimes change/remove comments and code they don't sufficiently understand as side effects, even if orthogonal to the task."
+| Principle | Working agreement | Prevents |
+| --- | --- | --- |
+| **Think Before Coding** | Surface assumptions, ambiguity, and tradeoffs before editing | Confident work based on the wrong interpretation |
+| **Simplicity First** | Write the minimum code that solves the current problem | Speculative features and premature abstractions |
+| **Surgical Changes** | Touch only lines that directly serve the request | Drive-by refactors and noisy diffs |
+| **Goal-Driven Execution** | Define success criteria and verify them | Vague implementation and untested completion claims |
 
-## The Solution
+The complete guidelines live in tool-native formats so you can adopt them without translating the rules yourself.
 
-Four principles in one file that directly address these issues:
+## Supported Integrations
 
-| Principle | Addresses |
-|-----------|-----------|
-| **Think Before Coding** | Wrong assumptions, hidden confusion, missing tradeoffs |
-| **Simplicity First** | Overcomplication, bloated abstractions |
-| **Surgical Changes** | Orthogonal edits, touching code you shouldn't |
-| **Goal-Driven Execution** | Leverage through tests-first, verifiable success criteria |
+| Tool | Repository file | Best for |
+| --- | --- | --- |
+| **Claude Code** | [`CLAUDE.md`](CLAUDE.md) and [`skills/karpathy-guidelines/SKILL.md`](skills/karpathy-guidelines/SKILL.md) | Plugin install, project instructions, or a reusable skill |
+| **OpenAI Codex** | [`AGENTS.md`](AGENTS.md) and [`skills/karpathy-guidelines/SKILL.md`](skills/karpathy-guidelines/SKILL.md) | Always-on project/global instructions or an invokable skill |
+| **Cursor** | [`.cursor/rules/karpathy-guidelines.mdc`](.cursor/rules/karpathy-guidelines.mdc) | An always-applied project rule |
+| **Other coding agents** | [`CLAUDE.md`](CLAUDE.md) | Copy or merge into the instruction file supported by your tool |
 
-## The Four Principles in Detail
+## Quick Start
 
-### 1. Think Before Coding
+### OpenAI Codex
 
-**Don't assume. Don't hide confusion. Surface tradeoffs.**
+Codex automatically reads `AGENTS.md` before it starts work. Choose the scope you want:
 
-LLMs often pick an interpretation silently and run with it. This principle forces explicit reasoning:
+#### Current project
 
-- **State assumptions explicitly** — If uncertain, ask rather than guess
-- **Present multiple interpretations** — Don't pick silently when ambiguity exists
-- **Push back when warranted** — If a simpler approach exists, say so
-- **Stop when confused** — Name what's unclear and ask for clarification
+For a project that does not already have `AGENTS.md`:
 
-### 2. Simplicity First
-
-**Minimum code that solves the problem. Nothing speculative.**
-
-Combat the tendency toward overengineering:
-
-- No features beyond what was asked
-- No abstractions for single-use code
-- No "flexibility" or "configurability" that wasn't requested
-- No error handling for impossible scenarios
-- If 200 lines could be 50, rewrite it
-
-**The test:** Would a senior engineer say this is overcomplicated? If yes, simplify.
-
-### 3. Surgical Changes
-
-**Touch only what you must. Clean up only your own mess.**
-
-When editing existing code:
-
-- Don't "improve" adjacent code, comments, or formatting
-- Don't refactor things that aren't broken
-- Match existing style, even if you'd do it differently
-- If you notice unrelated dead code, mention it — don't delete it
-
-When your changes create orphans:
-
-- Remove imports/variables/functions that YOUR changes made unused
-- Don't remove pre-existing dead code unless asked
-
-**The test:** Every changed line should trace directly to the user's request.
-
-### 4. Goal-Driven Execution
-
-**Define success criteria. Loop until verified.**
-
-Transform imperative tasks into verifiable goals:
-
-| Instead of... | Transform to... |
-|--------------|-----------------|
-| "Add validation" | "Write tests for invalid inputs, then make them pass" |
-| "Fix the bug" | "Write a test that reproduces it, then make it pass" |
-| "Refactor X" | "Ensure tests pass before and after" |
-
-For multi-step tasks, state a brief plan:
-
-```
-1. [Step] → verify: [check]
-2. [Step] → verify: [check]
-3. [Step] → verify: [check]
+```bash
+curl -L https://raw.githubusercontent.com/multica-ai/andrej-karpathy-skills/main/AGENTS.md -o AGENTS.md
 ```
 
-Strong success criteria let the LLM loop independently. Weak criteria ("make it work") require constant clarification.
+If the project already has `AGENTS.md`, merge the four principles into it instead of overwriting project-specific instructions.
 
-## Install
+#### Every Codex project
 
-**Option A: Claude Code Plugin (recommended)**
+Merge [`AGENTS.md`](AGENTS.md) into `~/.codex/AGENTS.md`. Codex loads this global file for every repository and then layers project-level instructions on top of it.
 
-From within Claude Code, first add the marketplace:
+Verify the result from a repository root:
+
+```bash
+codex --ask-for-approval never "Summarize the current instructions."
 ```
-/plugin marketplace add forrestchang/andrej-karpathy-skills
+
+#### Reusable Codex skill
+
+In Codex, ask the built-in skill installer to install this repository's skill:
+
+```text
+$skill-installer Install karpathy-guidelines from https://github.com/multica-ai/andrej-karpathy-skills/tree/main/skills/karpathy-guidelines
 ```
 
-Then install the plugin:
-```
+Then invoke it explicitly with `$karpathy-guidelines`, or let Codex select it when a coding task matches the skill description.
+
+See [`CODEX.md`](CODEX.md) for Windows commands, global vs. project scope, verification, and troubleshooting. The setup follows the official OpenAI documentation for [AGENTS.md](https://developers.openai.com/codex/guides/agents-md/) and [Codex skills](https://developers.openai.com/codex/skills/).
+
+### Claude Code
+
+#### Plugin install (recommended)
+
+From Claude Code, add this repository as a marketplace and install the plugin:
+
+```text
+/plugin marketplace add multica-ai/andrej-karpathy-skills
 /plugin install andrej-karpathy-skills@karpathy-skills
 ```
 
-This installs the guidelines as a Claude Code plugin, making the skill available across all your projects.
+This makes the reusable skill available across projects.
 
-**Option B: CLAUDE.md (per-project)**
+#### Project instructions
 
-New project:
+For a project that does not already have `CLAUDE.md`:
+
 ```bash
-curl -o CLAUDE.md https://raw.githubusercontent.com/forrestchang/andrej-karpathy-skills/main/CLAUDE.md
+curl -L https://raw.githubusercontent.com/multica-ai/andrej-karpathy-skills/main/CLAUDE.md -o CLAUDE.md
 ```
 
-Existing project (append):
+If `CLAUDE.md` already exists, merge the guidelines instead of replacing the file.
+
+### Cursor
+
+Copy the committed rule into another project's `.cursor/rules/` directory:
+
 ```bash
-echo "" >> CLAUDE.md
-curl https://raw.githubusercontent.com/forrestchang/andrej-karpathy-skills/main/CLAUDE.md >> CLAUDE.md
+mkdir -p .cursor/rules
+curl -L https://raw.githubusercontent.com/multica-ai/andrej-karpathy-skills/main/.cursor/rules/karpathy-guidelines.mdc -o .cursor/rules/karpathy-guidelines.mdc
 ```
 
-## Using with Cursor
+The rule uses `alwaysApply: true`, so it is active whenever that project is open in Cursor. See [`CURSOR.md`](CURSOR.md) for details.
 
-This repository includes a committed Cursor project rule ([`.cursor/rules/karpathy-guidelines.mdc`](.cursor/rules/karpathy-guidelines.mdc)) so the same guidelines apply when you open the project in Cursor. See **[CURSOR.md](CURSOR.md)** for setup, using the rule in other projects, and how this relates to Claude Code.
+## The Four Principles
 
-## Key Insight
+### 1. Think Before Coding
 
-From Andrej:
+**Do not assume. Do not hide confusion. Surface tradeoffs.**
 
-> "LLMs are exceptionally good at looping until they meet specific goals... Don't tell it what to do, give it success criteria and watch it go."
+- State important assumptions before implementing.
+- When multiple interpretations are plausible, present them instead of choosing silently.
+- Point out a simpler approach or a meaningful downside when one exists.
+- If missing information would materially change the solution, stop and ask.
 
-The "Goal-Driven Execution" principle captures this: transform imperative instructions into declarative goals with verification loops.
+### 2. Simplicity First
 
-## How to Know It's Working
+**Write the minimum code that solves the stated problem.**
 
-These guidelines are working if you see:
+- Do not add features that were not requested.
+- Do not create an abstraction for one use case.
+- Do not add configurability for hypothetical future needs.
+- Match complexity to evidence from the current requirements.
+- If 200 lines can clearly be 50, simplify.
 
-- **Fewer unnecessary changes in diffs** — Only requested changes appear
-- **Fewer rewrites due to overcomplication** — Code is simple the first time
-- **Clarifying questions come before implementation** — Not after mistakes
-- **Clean, minimal PRs** — No drive-by refactoring or "improvements"
+### 3. Surgical Changes
 
-## Customization
+**Touch only what the task requires. Clean up only what your change makes obsolete.**
 
-These guidelines are designed to be merged with project-specific instructions. Add them to your existing `CLAUDE.md` or create a new one.
+- Do not reformat, rename, or refactor adjacent code without a task-related reason.
+- Match the existing style and patterns.
+- Mention unrelated problems rather than silently fixing them.
+- Remove imports, variables, or functions only when your own change made them unused.
 
-For project-specific rules, add sections like:
+The test: every changed line should trace back to the request or to verification of the requested behavior.
+
+### 4. Goal-Driven Execution
+
+**Turn instructions into observable success criteria, then loop until verified.**
+
+| Request | Verifiable goal |
+| --- | --- |
+| “Add validation” | Add tests for invalid inputs, then make them pass |
+| “Fix the bug” | Reproduce it with a test, fix it, and run regression checks |
+| “Refactor X” | Establish passing checks before and after the refactor |
+
+For multi-step work, pair each step with its check:
+
+```text
+1. Reproduce the behavior -> verify: focused test fails for the expected reason
+2. Make the smallest fix -> verify: focused test passes
+3. Check for regressions -> verify: relevant suite and diff review pass
+```
+
+## What Good Adoption Looks Like
+
+- Clarifying questions happen before costly implementation, not after it.
+- Diffs contain fewer unrelated edits.
+- Solutions have fewer speculative layers and abstractions.
+- Completion reports name the checks that actually ran.
+- Pull requests are smaller, easier to review, and easier to revert.
+
+These are behavioral guidelines, not a substitute for project requirements, security policy, tests, or human review.
+
+## Repository Map
+
+```text
+.
+|-- AGENTS.md                              # Codex project instructions
+|-- CLAUDE.md                              # Claude Code project instructions
+|-- CODEX.md                               # Detailed Codex setup
+|-- CURSOR.md                              # Detailed Cursor setup
+|-- EXAMPLES.md                            # Before/after examples
+|-- .claude-plugin/                        # Claude Code plugin metadata
+|-- .cursor/rules/karpathy-guidelines.mdc  # Cursor project rule
+`-- skills/karpathy-guidelines/SKILL.md     # Reusable Agent Skill
+```
+
+## Customize Without Losing Project Context
+
+Treat these principles as a behavioral layer, then keep repository-specific facts in the native project instruction file:
 
 ```markdown
 ## Project-Specific Guidelines
 
-- Use TypeScript strict mode
-- All API endpoints must have tests
-- Follow the existing error handling patterns in `src/utils/errors.ts`
+- Use TypeScript strict mode.
+- Run `npm test` after changing application code.
+- Follow the error-handling pattern in `src/utils/errors.ts`.
 ```
 
-## Tradeoff Note
+When a target file already exists, review and merge. Blindly replacing it can delete important setup, testing, or safety instructions.
 
-These guidelines bias toward **caution over speed**. For trivial tasks (simple typo fixes, obvious one-liners), use judgment — not every change needs the full rigor.
+## Contributing
 
-The goal is reducing costly mistakes on non-trivial work, not slowing down simple tasks.
+The tool-specific files intentionally express the same four principles. When changing their behavior, keep these files aligned:
+
+- [`AGENTS.md`](AGENTS.md)
+- [`CLAUDE.md`](CLAUDE.md)
+- [`skills/karpathy-guidelines/SKILL.md`](skills/karpathy-guidelines/SKILL.md)
+- [`.cursor/rules/karpathy-guidelines.mdc`](.cursor/rules/karpathy-guidelines.mdc)
+
+Documentation-only wording can remain tool-specific when it explains installation or discovery behavior.
+
+## Tradeoff
+
+These guidelines bias toward caution over speed. Use judgment for obvious typo fixes and other trivial, low-risk work; the goal is to prevent expensive mistakes without turning every one-line edit into a ceremony.
+
+## Credits
+
+Inspired by [Andrej Karpathy's observations on coding agents](https://x.com/karpathy/status/2015883857489522876). Repository maintained by [Multica](https://github.com/multica-ai).
 
 ## License
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,170 +1,215 @@
-# 受 Karpathy 启发的 Claude Code 指南
+# 受 Karpathy 启发的编码智能体指南
 
-> 查看我的新项目 [Multica](https://github.com/multica-ai/multica) —— 一个用于运行和管理编码智能体的开源平台，支持可复用的技能。
->
-> 在 X 上关注我：[https://x.com/jiayuan_jy](https://x.com/jiayuan_jy)
+一套可移植的编码智能体行为准则，源自 [Andrej Karpathy 对常见 LLM 编码问题的观察](https://x.com/karpathy/status/2015883857489522876)。
 
-一个单一的 `CLAUDE.md` 文件，用于改善 Claude Code 的行为，源自 [Andrej Karpathy 的观察](https://x.com/karpathy/status/2015883857489522876) 关于 LLM 编码陷阱的总结。
+同一套四项原则可用于 **Claude Code**、**OpenAI Codex**、**Cursor**，以及任何支持项目指令或 Agent Skills 的编码智能体。
 
-[English](./README.md) | 简体中文
+[English](README.md) | 简体中文
 
-## 问题所在
+> 另请参阅 [Multica](https://github.com/multica-ai/multica)：一个使用可复用技能来运行编码智能体的开源平台。
 
-来自 Andrej 的推文：
+## 为什么需要这套指南
 
-> "模型会代你做错误假设，然后不假思索地执行。它们不管理自身的困惑，不寻求澄清，不呈现矛盾，不展示权衡，在应该提出异议时也不反驳。"
+编码智能体能力很强，但它们经常以可预测的方式失败：默默做出假设、过度设计、修改无关代码，以及在没有验证结果的情况下宣布完成。
 
-> "它们真的很喜欢把代码和 API 搞复杂，堆砌抽象概念，不清理死代码……明明 100 行能搞定的事情，非要实现成 1000 行的臃肿架构。"
+本仓库把这些失败模式转化为四项明确的工作约定：
 
-> "它们有时仍会改动或删除自己理解不足的代码和注释，即使这些内容与任务本身无关。"
+| 原则 | 工作约定 | 防止的问题 |
+| --- | --- | --- |
+| **编码前思考** | 编辑前明确假设、歧义与权衡 | 基于错误理解自信地推进 |
+| **简洁优先** | 只编写解决当前问题所需的最少代码 | 推测性功能与过早抽象 |
+| **精准修改** | 只改动直接服务于请求的内容 | 顺手重构与嘈杂 diff |
+| **目标驱动执行** | 定义成功标准并实际验证 | 模糊实现与未经测试的完成声明 |
 
-## 解决方案
+完整指南以各工具的原生格式提供，无需自行转换规则。
 
-四个原则，集中在一个文件中，直接解决这些问题：
+## 支持的集成
 
-| 原则 | 解决什么问题 |
-|-----------|-----------|
-| **编码前思考** | 错误假设、隐藏困惑、缺少权衡 |
-| **简洁优先** | 过度复杂、臃肿抽象 |
-| **精准修改** | 无关编辑、触碰不应碰的代码 |
-| **目标驱动执行** | 通过测试优先、可验证的成功标准 |
+| 工具 | 仓库文件 | 最适合的用法 |
+| --- | --- | --- |
+| **Claude Code** | [`CLAUDE.md`](CLAUDE.md) 与 [`skills/karpathy-guidelines/SKILL.md`](skills/karpathy-guidelines/SKILL.md) | 插件安装、项目指令或可复用技能 |
+| **OpenAI Codex** | [`AGENTS.md`](AGENTS.md) 与 [`skills/karpathy-guidelines/SKILL.md`](skills/karpathy-guidelines/SKILL.md) | 始终生效的项目/全局指令或可调用技能 |
+| **Cursor** | [`.cursor/rules/karpathy-guidelines.mdc`](.cursor/rules/karpathy-guidelines.mdc) | 始终应用的项目规则 |
+| **其他编码智能体** | [`CLAUDE.md`](CLAUDE.md) | 复制或合并到该工具支持的指令文件中 |
 
-## 四个原则详解
+## 快速开始
+
+### OpenAI Codex
+
+Codex 会在开始工作前自动读取 `AGENTS.md`。请选择所需作用域：
+
+#### 当前项目
+
+如果项目中还没有 `AGENTS.md`：
+
+```bash
+curl -L https://raw.githubusercontent.com/multica-ai/andrej-karpathy-skills/main/AGENTS.md -o AGENTS.md
+```
+
+如果项目已经有 `AGENTS.md`，请把四项原则合并进去，不要覆盖项目专用指令。
+
+#### 所有 Codex 项目
+
+将 [`AGENTS.md`](AGENTS.md) 合并到 `~/.codex/AGENTS.md`。Codex 会为每个仓库加载这个全局文件，然后在其上叠加项目级指令。
+
+在仓库根目录验证结果：
+
+```bash
+codex --ask-for-approval never "Summarize the current instructions."
+```
+
+#### 可复用 Codex 技能
+
+在 Codex 中，让内置的 skill installer 安装本仓库的技能：
+
+```text
+$skill-installer Install karpathy-guidelines from https://github.com/multica-ai/andrej-karpathy-skills/tree/main/skills/karpathy-guidelines
+```
+
+之后可用 `$karpathy-guidelines` 显式调用；当编码任务符合技能描述时，Codex 也可以自动选择它。
+
+Windows 命令、全局与项目作用域、验证和故障排除请参阅 [`CODEX.md`](CODEX.md)。该设置遵循 OpenAI 官方的 [AGENTS.md](https://developers.openai.com/codex/guides/agents-md/) 与 [Codex skills](https://developers.openai.com/codex/skills/) 文档。
+
+### Claude Code
+
+#### 安装插件（推荐）
+
+在 Claude Code 中，将本仓库添加为 marketplace 并安装插件：
+
+```text
+/plugin marketplace add multica-ai/andrej-karpathy-skills
+/plugin install andrej-karpathy-skills@karpathy-skills
+```
+
+这样可在所有项目中使用该可复用技能。
+
+#### 项目指令
+
+如果项目中还没有 `CLAUDE.md`：
+
+```bash
+curl -L https://raw.githubusercontent.com/multica-ai/andrej-karpathy-skills/main/CLAUDE.md -o CLAUDE.md
+```
+
+如果 `CLAUDE.md` 已存在，请合并指南，不要替换原文件。
+
+### Cursor
+
+将已提交的规则复制到另一个项目的 `.cursor/rules/` 目录：
+
+```bash
+mkdir -p .cursor/rules
+curl -L https://raw.githubusercontent.com/multica-ai/andrej-karpathy-skills/main/.cursor/rules/karpathy-guidelines.mdc -o .cursor/rules/karpathy-guidelines.mdc
+```
+
+规则使用 `alwaysApply: true`，因此只要在 Cursor 中打开该项目就会生效。详情请参阅 [`CURSOR.md`](CURSOR.md)。
+
+## 四项原则
 
 ### 1. 编码前思考
 
 **不要假设。不要隐藏困惑。呈现权衡。**
 
-LLM 经常默默选择一种解释然后执行。这个原则强制明确推理：
-
-- **明确说明假设** — 如果不确定，询问而不是猜测
-- **呈现多种解释** — 当存在歧义时，不要默默选择
-- **适时提出异议** — 如果存在更简单的方法，说出来
-- **困惑时停下来** — 指出不清楚的地方并要求澄清
+- 实现前说明重要假设。
+- 当存在多种合理解释时，列出它们，不要默默选择。
+- 如果有更简单的方案或明显代价，应主动指出。
+- 如果缺失信息会实质性改变方案，请停止并询问。
 
 ### 2. 简洁优先
 
-**用最少的代码解决问题。不要过度推测。**
+**只编写解决当前问题所需的最少代码。**
 
-对抗过度工程的倾向：
-
-- 不要添加要求之外的功能
-- 不要为一次性代码创建抽象
-- 不要添加未要求的"灵活性"或"可配置性"
-- 不要为不可能发生的场景做错误处理
-- 如果 200 行代码可以写成 50 行，重写它
-
-**检验标准：** 资深工程师会觉得这过于复杂吗？如果是，简化。
+- 不添加未被要求的功能。
+- 不为单一用例创建抽象。
+- 不为假想的未来需求添加可配置性。
+- 让复杂度与当前需求中的证据相匹配。
+- 如果 200 行显然可以写成 50 行，就简化。
 
 ### 3. 精准修改
 
-**只碰必须碰的。只清理自己造成的混乱。**
+**只触碰任务要求的内容。只清理因本次修改而过时的内容。**
 
-编辑现有代码时：
+- 没有与任务相关的理由时，不要格式化、重命名或重构相邻代码。
+- 匹配现有风格与模式。
+- 对无关问题进行说明，而不是默默修复。
+- 只有当自己的修改使导入、变量或函数不再使用时才删除它们。
 
-- 不要"改进"相邻的代码、注释或格式
-- 不要重构没坏的东西
-- 匹配现有风格，即使你更倾向于不同的写法
-- 如果注意到无关的死代码，提一下 —— 不要删除它
-
-当你的改动产生孤儿代码时：
-
-- 删除因你的改动而变得无用的导入/变量/函数
-- 不要删除预先存在的死代码，除非被要求
-
-**检验标准：** 每一行修改都应该能直接追溯到用户的请求。
+检验标准：每一行改动都应能追溯到用户请求，或追溯到对所请求行为的验证。
 
 ### 4. 目标驱动执行
 
-**定义成功标准。循环验证直到达成。**
+**把指令转化为可观察的成功标准，然后循环执行直到验证通过。**
 
-将指令式任务转化为可验证的目标：
+| 请求 | 可验证目标 |
+| --- | --- |
+| “添加验证” | 为无效输入添加测试，然后让测试通过 |
+| “修复 bug” | 用测试重现问题、修复问题并运行回归检查 |
+| “重构 X” | 确保重构前后的检查都通过 |
 
-| 不要这样做... | 转化为... |
-|--------------|-----------------|
-| "添加验证" | "为无效输入编写测试，然后让它们通过" |
-| "修复 bug" | "编写重现 bug 的测试，然后让它通过" |
-| "重构 X" | "确保重构前后测试都能通过" |
+对于多步骤工作，为每一步配对检查项：
 
-对于多步骤任务，说明一个简短的计划：
-
-```
-1. [步骤] → 验证: [检查]
-2. [步骤] → 验证: [检查]
-3. [步骤] → 验证: [检查]
+```text
+1. 重现行为 -> 验证：聚焦测试按预期原因失败
+2. 完成最小修复 -> 验证：聚焦测试通过
+3. 检查回归 -> 验证：相关测试套件与 diff 审查通过
 ```
 
-强有力的成功标准让 LLM 能够独立循环执行。弱标准（"让它工作"）需要不断澄清。
+## 正确采用后的表现
 
-## 安装
+- 澄清问题发生在高成本实现之前，而不是错误发生之后。
+- diff 中无关编辑更少。
+- 解决方案中的推测性层次和抽象更少。
+- 完成报告会明确列出实际运行过的检查。
+- Pull request 更小、更易审查，也更易回滚。
 
-**选项 A：Claude Code 插件（推荐）**
+这些行为准则不能替代项目要求、安全策略、测试或人工审查。
 
-在 Claude Code 中，首先添加插件市场：
-```
-/plugin marketplace add forrestchang/andrej-karpathy-skills
-```
+## 仓库结构
 
-然后安装插件：
-```
-/plugin install andrej-karpathy-skills@karpathy-skills
-```
-
-这会将指南安装为 Claude Code 插件，使其在你所有项目中可用。
-
-**选项 B：CLAUDE.md（按项目）**
-
-新项目：
-```bash
-curl -o CLAUDE.md https://raw.githubusercontent.com/forrestchang/andrej-karpathy-skills/main/CLAUDE.md
-```
-
-已有项目（追加）：
-```bash
-echo "" >> CLAUDE.md
-curl https://raw.githubusercontent.com/forrestchang/andrej-karpathy-skills/main/CLAUDE.md >> CLAUDE.md
+```text
+.
+|-- AGENTS.md                              # Codex 项目指令
+|-- CLAUDE.md                              # Claude Code 项目指令
+|-- CODEX.md                               # Codex 详细设置
+|-- CURSOR.md                              # Cursor 详细设置
+|-- EXAMPLES.md                            # 修改前/后的示例
+|-- .claude-plugin/                        # Claude Code 插件元数据
+|-- .cursor/rules/karpathy-guidelines.mdc  # Cursor 项目规则
+`-- skills/karpathy-guidelines/SKILL.md     # 可复用 Agent Skill
 ```
 
-## 在 Cursor 中使用
+## 在不丢失项目上下文的前提下定制
 
-本仓库包含一个已提交的 Cursor 项目规则 ([`.cursor/rules/karpathy-guidelines.mdc`](.cursor/rules/karpathy-guidelines.mdc))，因此在 Cursor 中打开项目时同样适用这些指南。详情请参见 **[CURSOR.md](CURSOR.md)**，包括如何在其他项目中使用该规则，以及它与 Claude Code 的关系。
-
-## 核心洞察
-
-来自 Andrej：
-
-> "LLM 非常擅长循环执行直到达成特定目标……不要告诉它该做什么，给它成功标准，然后看着它完成。"
-
-"目标驱动执行"原则正是捕捉了这一点：将指令式指令转化为带有验证循环的声明式目标。
-
-## 如何判断它在起作用
-
-如果你看到以下情况，说明这些指南正在发挥作用：
-
-- **diff 中不必要的改动更少** —— 只有请求的改动出现
-- **因过度复杂而导致的重写更少** —— 代码第一次就写得简洁
-- **澄清问题在实现之前提出** —— 而不是在犯错之后
-- **干净、精简的 PR** —— 没有顺带的重构或"改进"
-
-## 定制
-
-这些指南设计用于与项目特定指令合并。将它们添加到你现有的 `CLAUDE.md` 或创建一个新的。
-
-对于项目特定规则，添加如下章节：
+把这四项原则作为行为层，并在原生项目指令文件中保留仓库特定事实：
 
 ```markdown
-## 项目特定指南
+## 项目专用指南
 
-- 使用 TypeScript 严格模式
-- 所有 API 端点必须有测试
-- 遵循 `src/utils/errors.ts` 中现有的错误处理模式
+- 使用 TypeScript strict mode。
+- 修改应用代码后运行 `npm test`。
+- 遵循 `src/utils/errors.ts` 中的错误处理模式。
 ```
 
-## 权衡说明
+如果目标文件已经存在，请审查并合并。直接替换可能删除重要的设置、测试或安全指令。
 
-这些指南倾向于**谨慎而非速度**。对于琐碎的任务（简单的拼写错误修复、显而易见的一行修改），请自行判断 —— 并非每个改动都需要完整的严谨流程。
+## 贡献
 
-目标是减少非琐碎工作中的代价高昂的错误，而不是拖慢简单任务。
+各工具专用文件有意表达相同的四项原则。修改其行为时，请保持以下文件一致：
+
+- [`AGENTS.md`](AGENTS.md)
+- [`CLAUDE.md`](CLAUDE.md)
+- [`skills/karpathy-guidelines/SKILL.md`](skills/karpathy-guidelines/SKILL.md)
+- [`.cursor/rules/karpathy-guidelines.mdc`](.cursor/rules/karpathy-guidelines.mdc)
+
+用于解释安装或发现机制的文档措辞可以保持工具特定形式。
+
+## 权衡
+
+本指南偏向谨慎而不是速度。对于明显的拼写修复和其他低风险小改动，请自行判断；目标是避免代价高昂的错误，而不是把每个单行修改都变成繁琐流程。
+
+## 致谢
+
+灵感来自 [Andrej Karpathy 对编码智能体的观察](https://x.com/karpathy/status/2015883857489522876)。仓库由 [Multica](https://github.com/multica-ai) 维护。
 
 ## 许可
 


### PR DESCRIPTION
## Summary

- rewrite the English and Simplified Chinese READMEs around a cross-agent integration matrix
- add first-class OpenAI Codex support with native `AGENTS.md` instructions and a detailed `CODEX.md` setup guide
- document project-wide, global, and reusable-skill installation paths for Codex
- update repository URLs to `multica-ai/andrej-karpathy-skills`
- keep Cursor documentation aligned with Claude Code and Codex

## Verification

- `git diff --check`
- `markdownlint` on README.md, README.zh.md, AGENTS.md, CODEX.md, and CURSOR.md (MD013 disabled for existing long-form style)
- verified all relative Markdown links resolve
- verified Markdown code fences are balanced
- parsed both Claude plugin JSON manifests
- checked Codex, Claude Code, and Cursor setup against their current official documentation