### PR TITLE
feat: add Google Antigravity & Gemini CLI support with Makefile

### DIFF
--- a/.agents/skills/karpathy-guidelines/SKILL.md
+++ b/.agents/skills/karpathy-guidelines/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: karpathy-guidelines
+description: Behavioral guidelines to reduce common LLM coding mistakes. Use when writing, reviewing, or refactoring code to avoid overcomplication, make surgical changes, surface assumptions, and define verifiable success criteria.
+license: MIT
+---
+
+# Karpathy Guidelines
+
+Behavioral guidelines to reduce common LLM coding mistakes, derived from [Andrej Karpathy's observations](https://x.com/karpathy/status/2015883857489522876) on LLM coding pitfalls.
+
+**Tradeoff:** These guidelines bias toward caution over speed. For trivial tasks, use judgment.
+
+## 1. Think Before Coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+Before implementing:
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them - don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+## 2. Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+## 3. Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it - don't delete it.
+
+When your changes create orphans:
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
+## 4. Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+```
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+```
+
+Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,65 @@
+# GEMINI.md
+
+Behavioral guidelines to reduce common LLM coding mistakes. Merge with project-specific instructions as needed.
+
+**Tradeoff:** These guidelines bias toward caution over speed. For trivial tasks, use judgment.
+
+## 1. Think Before Coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+Before implementing:
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them - don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+## 2. Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+## 3. Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it - don't delete it.
+
+When your changes create orphans:
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
+## 4. Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+```
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+```
+
+Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
+
+---
+
+**These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.

--- a/ANTIGRAVITY.md
+++ b/ANTIGRAVITY.md
@@ -1,0 +1,48 @@
+# Using this repo with Antigravity
+
+This project includes the Karpathy-inspired behavioral guidelines as an **Antigravity skill** so they apply when Antigravity detects a relevant task.
+
+## In this repository
+
+1. Open the folder in your editor with Antigravity active.
+2. The skill [`.agents/skills/karpathy-guidelines/SKILL.md`](.agents/skills/karpathy-guidelines/SKILL.md) is committed — Antigravity reads it automatically from `.agents/skills/` when working in this project.
+3. No extra installation steps are required.
+
+## Use the same guidelines in another project
+
+Antigravity supports two installation scopes:
+
+| Location | Scope |
+|----------|-------|
+| `<workspace-root>/.agents/skills/karpathy-guidelines/` | Workspace-specific (this project only) |
+| `~/.gemini/config/skills/karpathy-guidelines/` | Global (applies to all workspaces) |
+
+**Workspace-specific:** Copy the `.agents/skills/karpathy-guidelines/` folder into the target project root or run:
+
+```bash
+make antigravity
+```
+
+**Global (all workspaces):** Copy the skill folder into your Antigravity global skills directory or run:
+
+```bash
+make antigravity-global
+```
+
+Antigravity will pick up the skill automatically from either location.
+
+
+## Always-On Rules (`GEMINI.md` / `AGENTS.md`)
+
+If you prefer guidelines to be active on *every interaction* unconditionally:
+- Copy `GEMINI.md` or `AGENTS.md` into your target workspace root, or append its contents to `AGENTS.md`.
+
+## Claude Code vs Cursor vs Antigravity
+
+- **Claude Code:** Install via the plugin marketplace; see [`README.md`](README.md). Per-project use can rely on `CLAUDE.md`.
+- **Cursor:** Use the committed `.cursor/rules/karpathy-guidelines.mdc` file; see [`CURSOR.md`](CURSOR.md).
+- **Antigravity:** Copy `.agents/skills/karpathy-guidelines/` to the workspace or global skills directory, or use `GEMINI.md`/`AGENTS.md` for continuous rule enforcement.
+
+## For contributors
+
+When you change the four principles, keep **[`CLAUDE.md`](CLAUDE.md)**, **[`.cursor/rules/karpathy-guidelines.mdc`](.cursor/rules/karpathy-guidelines.mdc)**, **[`GEMINI.md`](GEMINI.md)**, and **[`.agents/skills/karpathy-guidelines/SKILL.md`](.agents/skills/karpathy-guidelines/SKILL.md)** in sync.

--- a/CURSOR.md
+++ b/CURSOR.md
@@ -10,13 +10,16 @@ This project includes a **Cursor project rule** so the Karpathy-inspired behavio
 
 ## Use the same guidelines in another project
 
-**Cursor (recommended):** Copy `.cursor/rules/karpathy-guidelines.mdc` into that project’s `.cursor/rules/` directory (create the folders if needed). Adjust or merge with existing rules as you like.
+**Local installation:** Copy `.cursor/rules/karpathy-guidelines.mdc` into that project’s `.cursor/rules/` directory (or run `make cursor`).
+
+**Global installation:** Copy to `~/.cursor/rules/` and `~/.cursor/skills/` (or run `make cursor-global`).
 
 **Other tools:** If a stack only supports a root instruction file, copy [`CLAUDE.md`](CLAUDE.md) into that project instead (or merge its contents into your existing instructions).
 
 ## Optional: personal Agent Skills
 
-If you want the same content as a reusable skill under `~/.cursor/skills`, use [`skills/karpathy-guidelines/SKILL.md`](skills/karpathy-guidelines/SKILL.md). You can copy or symlink it into your personal skills directory; use whatever layout you use for other skills.
+If you want the same content as a reusable skill under `~/.cursor/skills`, use [`skills/karpathy-guidelines/SKILL.md`](skills/karpathy-guidelines/SKILL.md). You can copy or symlink it into your personal skills directory, or run `make cursor-global`.
+
 
 ## Claude Code vs Cursor
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,65 @@
+# GEMINI.md
+
+Behavioral guidelines to reduce common LLM coding mistakes. Merge with project-specific instructions as needed.
+
+**Tradeoff:** These guidelines bias toward caution over speed. For trivial tasks, use judgment.
+
+## 1. Think Before Coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+Before implementing:
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them - don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+## 2. Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+## 3. Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it - don't delete it.
+
+When your changes create orphans:
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
+## 4. Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+```
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+```
+
+Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
+
+---
+
+**These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,74 @@
+.PHONY: help gemini gemini-global antigravity antigravity-global claude claude-global cursor cursor-global install-all install-all-global
+
+# Default target
+help:
+	@echo "Available Makefile targets:"
+	@echo "  make gemini             Install Gemini/Antigravity skill and GEMINI.md in local project"
+	@echo "  make gemini-global      Install Gemini/Antigravity skill globally (~/.gemini/config/skills/)"
+	@echo "  make antigravity        Alias for 'make gemini'"
+	@echo "  make antigravity-global Alias for 'make gemini-global'"
+	@echo "  make claude             Copy CLAUDE.md to local project root"
+	@echo "  make claude-global      Install global CLAUDE.md (~/.claude/CLAUDE.md)"
+	@echo "  make cursor             Copy Cursor rules to .cursor/rules/ in local project"
+	@echo "  make cursor-global      Install Cursor rules and skills globally (~/.cursor/rules/ & ~/.cursor/skills/)"
+	@echo "  make install-all        Install all local integrations (Gemini, Claude, Cursor)"
+	@echo "  make install-all-global Install all global integrations (Gemini, Claude, Cursor)"
+
+# Gemini / Antigravity Local Installation
+gemini antigravity:
+	@echo "Installing Gemini/Antigravity skill and rules locally..."
+	@mkdir -p .agents/skills/karpathy-guidelines
+	@cp skills/karpathy-guidelines/SKILL.md .agents/skills/karpathy-guidelines/SKILL.md
+	@cp GEMINI.md GEMINI.md 2>/dev/null || true
+	@cp AGENTS.md AGENTS.md 2>/dev/null || true
+	@echo "Done! Local Antigravity/Gemini installation complete."
+
+# Gemini / Antigravity Global Installation
+gemini-global antigravity-global:
+	@echo "Installing Gemini/Antigravity skill globally..."
+	@mkdir -p ~/.gemini/config/skills/karpathy-guidelines
+	@cp skills/karpathy-guidelines/SKILL.md ~/.gemini/config/skills/karpathy-guidelines/SKILL.md
+	@echo "Done! Global Antigravity/Gemini skill installed to ~/.gemini/config/skills/karpathy-guidelines/"
+
+# Claude Code Local Installation
+claude:
+	@echo "Installing Claude Code rules locally..."
+	@cp CLAUDE.md CLAUDE.md
+	@echo "Done! CLAUDE.md installed to project root."
+
+# Claude Code Global Installation
+claude-global:
+	@echo "Installing Claude Code rules globally..."
+	@mkdir -p ~/.claude
+	@if [ -f ~/.claude/CLAUDE.md ]; then \
+		echo "" >> ~/.claude/CLAUDE.md; \
+		cat CLAUDE.md >> ~/.claude/CLAUDE.md; \
+		echo "Appended Karpathy Guidelines to ~/.claude/CLAUDE.md"; \
+	else \
+		cp CLAUDE.md ~/.claude/CLAUDE.md; \
+		echo "Created ~/.claude/CLAUDE.md with Karpathy Guidelines"; \
+	fi
+	@echo "Done! Global Claude Code instructions updated."
+
+# Cursor Local Installation
+cursor:
+	@echo "Installing Cursor rules locally..."
+	@mkdir -p .cursor/rules
+	@cp .cursor/rules/karpathy-guidelines.mdc .cursor/rules/karpathy-guidelines.mdc
+	@echo "Done! Cursor rule installed to .cursor/rules/"
+
+# Cursor Global Installation
+cursor-global:
+	@echo "Installing Cursor rules and skills globally..."
+	@mkdir -p ~/.cursor/rules ~/.cursor/skills/karpathy-guidelines
+	@cp .cursor/rules/karpathy-guidelines.mdc ~/.cursor/rules/karpathy-guidelines.mdc
+	@cp skills/karpathy-guidelines/SKILL.md ~/.cursor/skills/karpathy-guidelines/SKILL.md
+	@echo "Done! Global Cursor rule (~/.cursor/rules/) and skill (~/.cursor/skills/) installed."
+
+# Install all local integrations
+install-all: gemini claude cursor
+	@echo "All local integrations installed successfully!"
+
+# Install all global integrations
+install-all-global: gemini-global claude-global cursor-global
+	@echo "All global integrations installed successfully!"

--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,8 @@ gemini-global antigravity-global:
 # Claude Code Local Installation
 claude:
 	@echo "Installing Claude Code rules locally..."
-	@cp CLAUDE.md CLAUDE.md
-	@echo "Done! CLAUDE.md installed to project root."
+	@test -f CLAUDE.md || cp CLAUDE.md CLAUDE.md 2>/dev/null || true
+	@echo "Done! CLAUDE.md available at project root."
 
 # Claude Code Global Installation
 claude-global:
@@ -54,8 +54,8 @@ claude-global:
 cursor:
 	@echo "Installing Cursor rules locally..."
 	@mkdir -p .cursor/rules
-	@cp .cursor/rules/karpathy-guidelines.mdc .cursor/rules/karpathy-guidelines.mdc
-	@echo "Done! Cursor rule installed to .cursor/rules/"
+	@test -f .cursor/rules/karpathy-guidelines.mdc || cp .cursor/rules/karpathy-guidelines.mdc .cursor/rules/karpathy-guidelines.mdc 2>/dev/null || true
+	@echo "Done! Cursor rule available at .cursor/rules/"
 
 # Cursor Global Installation
 cursor-global:

--- a/README.md
+++ b/README.md
@@ -129,6 +129,22 @@ curl https://raw.githubusercontent.com/forrestchang/andrej-karpathy-skills/main/
 
 This repository includes a committed Cursor project rule ([`.cursor/rules/karpathy-guidelines.mdc`](.cursor/rules/karpathy-guidelines.mdc)) so the same guidelines apply when you open the project in Cursor. See **[CURSOR.md](CURSOR.md)** for setup, using the rule in other projects, and how this relates to Claude Code.
 
+## Using with Google Antigravity / Gemini CLI
+
+This repository includes `GEMINI.md` and `AGENTS.md` for native integration with Google Antigravity.
+
+**Option A: Global Skill (across all projects)**
+```bash
+mkdir -p ~/.gemini/config/skills/karpathy-guidelines
+curl -sSL https://raw.githubusercontent.com/multica-ai/andrej-karpathy-skills/main/skills/karpathy-guidelines/SKILL.md -o ~/.gemini/config/skills/karpathy-guidelines/SKILL.md
+```
+
+**Option B: Always-On Project Rules (`GEMINI.md` or `AGENTS.md`)**
+```bash
+curl -o GEMINI.md https://raw.githubusercontent.com/multica-ai/andrej-karpathy-skills/main/GEMINI.md
+```
+
+
 ## Key Insight
 
 From Andrej:

--- a/README.zh.md
+++ b/README.zh.md
@@ -129,6 +129,17 @@ curl https://raw.githubusercontent.com/forrestchang/andrej-karpathy-skills/main/
 
 本仓库包含一个已提交的 Cursor 项目规则 ([`.cursor/rules/karpathy-guidelines.mdc`](.cursor/rules/karpathy-guidelines.mdc))，因此在 Cursor 中打开项目时同样适用这些指南。详情请参见 **[CURSOR.md](CURSOR.md)**，包括如何在其他项目中使用该规则，以及它与 Claude Code 的关系。
 
+## 在 Antigravity 中使用
+
+本仓库将指南作为 Antigravity skill 提供 ([`.agents/skills/karpathy-guidelines/SKILL.md`](.agents/skills/karpathy-guidelines/SKILL.md))，Antigravity 激活时会自动应用这些指南。详情请参见 **[ANTIGRAVITY.md](ANTIGRAVITY.md)**，包括如何为单个工作区或全局所有工作区安装该 skill。
+
+| 范围 | 路径 |
+|------|------|
+| 工作区专用 | `<workspace-root>/.agents/skills/karpathy-guidelines/` |
+| 全局（所有工作区）| `~/.gemini/config/skills/karpathy-guidelines/` |
+
+
+
 ## 核心洞察
 
 来自 Andrej：


### PR DESCRIPTION
## Description
This PR adds native support for **Google Antigravity** and **Gemini CLI**, along with a unified `Makefile` for installing rules and skills locally and globally across supported AI tools (Google Antigravity, Claude Code, and Cursor).

## Changes Included
- **`ANTIGRAVITY.md`**: Guide for setting up Google Antigravity (workspace vs global).
- **`GEMINI.md` & `AGENTS.md`**: Always-on rules for Google Antigravity and Gemini CLI.
- **`.agents/skills/karpathy-guidelines/SKILL.md`**: Native Antigravity skill directory structure.
- **`Makefile`**: Universal Makefile targets (`make antigravity`, `make antigravity-global`, `make claude`, `make claude-global`, `make cursor`, `make cursor-global`, `make install-all`, `make install-all-global`).
- **`README.md` & `README.zh.md`**: Updated documentation with Google Antigravity / Gemini CLI sections.
- **`CURSOR.md`**: Updated with Makefile shortcuts.